### PR TITLE
Statically link libs for general Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:latest as builder
-WORKDIR /app
+FROM clux/muslrust:stable AS builder
+WORKDIR /usr/src/
 COPY . .
-RUN cargo build --release
+RUN cargo build --release --target x86_64-unknown-linux-musl
     
 FROM debian:buster-slim
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ FROM debian:buster-slim
 WORKDIR /app
 RUN apt update && \
     apt-get install pkg-config libssl-dev -y
-COPY --from=builder /app/target/release/turn-server /usr/local/bin/turn-server
-COPY --from=builder /app/turn-server.toml /etc/turn-server/config.toml
+COPY --from=builder /usr/src/target/x86_64-unknown-linux-musl/release/turn-server /usr/local/bin/turn-server
+COPY --from=builder /usr/src/turn-server.toml /etc/turn-server/config.toml
 CMD turn-server --config=/etc/turn-server/config.toml


### PR DESCRIPTION
The docker image as-is requires the host to have libraries. Recommend statically linking them instead so that it works across environments.