### PR TITLE
Fix patch for version 3.3.0

### DIFF
--- a/docs/http-hooks.md
+++ b/docs/http-hooks.md
@@ -21,7 +21,6 @@ Get the current user's password, which is mainly used to provide authentication 
 
 -   `address` - <sup>string</sup> - The IP address and port number of the UDP or TCP connection used by the client.
 -   `interface` - <sup>string</sup> - The network interface used by the current session.
--   `transport` - <sup>string</sup> - TCP | UDP.
 
 ---
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -29,7 +29,7 @@ Get the information of the turn server, including version information, listening
 
 ---
 
-### GET `/session?address=&interface=&transport=` - Session[]
+### GET `/session?address=&interface=` - Session[]
 
 Session:
 
@@ -45,7 +45,7 @@ Get session information. A session corresponds to each UDP socket. It should be 
 
 ---
 
-### GET - `/session/statistics?address=&interface=&transport=` - Statistics
+### GET - `/session/statistics?address=&interface=` - Statistics
 
 Statistics:
 
@@ -53,12 +53,11 @@ Statistics:
 -   `send_bytes` - <sup>uint64</sup> - The number of bytes sent by the current session
 -   `received_pkts` - <sup>uint64</sup> - Number of packets received in the current session
 -   `send_pkts` - <sup>uint64</sup> - The number of packets sent by the current session
--   `error_pkts` - <sup>uint64</sup> - The number of packets error by the current session
 
 Get session statistics, which is mainly the traffic statistics of the current session.
 
 ---
 
-### DELETE - `/session?address=&interface=&transport=`
+### DELETE - `/session?address=&interface=`
 
 Delete the session. Deleting the session will cause the turn server to delete all routing information of the current session. If there is a peer, the peer will also be disconnected.

--- a/drivers/examples/simple.rs
+++ b/drivers/examples/simple.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use async_trait::async_trait;
 use clap::Parser;
 use tabled::{Table, Tabled};
-use turn_driver::{start_hooks_server, Controller, Events, Hooks, Symbol, Transport};
+use turn_driver::{start_hooks_server, Controller, Events, Hooks, Socket, Transport};
 
 struct HooksImpl;
 
@@ -11,14 +11,14 @@ struct HooksImpl;
 impl Hooks for HooksImpl {
     async fn auth(
         &self,
-        session: &Symbol,
+        session: &Socket,
         username: &str,
         realm: &str,
         nonce: &str,
     ) -> Option<&str> {
         println!(
-            "auth: address={:?}, interface={:?}, transport={:?}, username={:?}, realm={}, nonce={}",
-            session.address, session.interface, session.transport, username, realm, nonce
+            "auth: address={:?}, interface={:?}, username={:?}, realm={}, nonce={}",
+            session.address, session.interface, username, realm, nonce
         );
 
         Some("test")

--- a/drivers/examples/simple.rs
+++ b/drivers/examples/simple.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use async_trait::async_trait;
 use clap::Parser;
 use tabled::{Table, Tabled};
-use turn_driver::{start_hooks_server, Controller, Events, Hooks, Socket, Transport};
+use turn_driver::{start_hooks_server, Controller, Events, Hooks, SessionAddr, Transport};
 
 struct HooksImpl;
 
@@ -11,14 +11,14 @@ struct HooksImpl;
 impl Hooks for HooksImpl {
     async fn auth(
         &self,
-        session: &Socket,
+        addr: &SessionAddr,
         username: &str,
         realm: &str,
         nonce: &str,
     ) -> Option<&str> {
         println!(
             "auth: address={:?}, interface={:?}, username={:?}, realm={}, nonce={}",
-            session.address, session.interface, username, realm, nonce
+            addr.address, addr.interface, username, realm, nonce
         );
 
         Some("test")

--- a/stun/src/lib.rs
+++ b/stun/src/lib.rs
@@ -131,29 +131,15 @@ pub enum Method {
 }
 
 impl Method {
-    #[rustfmt::skip]
-    pub fn into_response(self) -> Option<Self> {
-        Some(match self {
-            Method::Binding(Kind::Request) => Method::Binding(Kind::Response),
-            Method::Allocate(Kind::Request) => Method::Allocate(Kind::Response),
-            Method::CreatePermission(Kind::Request) => Method::CreatePermission(Kind::Response),
-            Method::ChannelBind(Kind::Request) => Method::ChannelBind(Kind::Response),
-            Method::Refresh(Kind::Request) => Method::Refresh(Kind::Response),
-            Method::SendIndication => Method::DataIndication,
-            _ => return None,
-        })
-    }
-
-    #[rustfmt::skip]
-    pub fn into_error(self) -> Option<Self> {
-        Some(match self {
-            Method::Binding(Kind::Request) => Method::Binding(Kind::Error),
-            Method::Allocate(Kind::Request) => Method::Allocate(Kind::Error),
-            Method::CreatePermission(Kind::Request) => Method::CreatePermission(Kind::Error),
-            Method::ChannelBind(Kind::Request) => Method::ChannelBind(Kind::Error),
-            Method::Refresh(Kind::Request) => Method::Refresh(Kind::Error),
-            _ => return None,
-        })
+    pub fn is_error(&self) -> bool {
+        match self {
+            Method::Binding(Kind::Error)
+            | Method::Refresh(Kind::Error)
+            | Method::Allocate(Kind::Error)
+            | Method::CreatePermission(Kind::Error)
+            | Method::ChannelBind(Kind::Error) => true,
+            _ => false,
+        }
     }
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -320,7 +320,7 @@ mod tests {
     use async_trait::async_trait;
     use base64::{prelude::BASE64_STANDARD, Engine};
     use tokio::time::sleep;
-    use turn_driver::{start_hooks_server, Controller, Events, Hooks, Socket, Transport};
+    use turn_driver::{start_hooks_server, Controller, Events, Hooks, SessionAddr, Transport};
     use turn_server::config::{Api, Auth};
 
     fn encode_password(username: &str, password: &str) -> Result<String> {
@@ -337,7 +337,7 @@ mod tests {
     impl Hooks for HooksImpl {
         async fn auth(
             &self,
-            _session: &Socket,
+            _addr: &SessionAddr,
             username: &str,
             _realm: &str,
             _nonce: &str,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -320,7 +320,7 @@ mod tests {
     use async_trait::async_trait;
     use base64::{prelude::BASE64_STANDARD, Engine};
     use tokio::time::sleep;
-    use turn_driver::{start_hooks_server, Controller, Events, Hooks, Symbol, Transport};
+    use turn_driver::{start_hooks_server, Controller, Events, Hooks, Socket, Transport};
     use turn_server::config::{Api, Auth};
 
     fn encode_password(username: &str, password: &str) -> Result<String> {
@@ -337,7 +337,7 @@ mod tests {
     impl Hooks for HooksImpl {
         async fn auth(
             &self,
-            _session: &Symbol,
+            _session: &Socket,
             username: &str,
             _realm: &str,
             _nonce: &str,
@@ -350,13 +350,13 @@ mod tests {
         }
 
         async fn on(&self, event: &Events, realm: &str, nonce: &str) {
-            let get_session = |symbol, username: String| async move {
-                let ret = self.0.get_session(symbol).await.unwrap();
+            let get_session = |socket, username: String| async move {
+                let ret = self.0.get_session(socket).await.unwrap();
                 assert_eq!(ret.realm, realm);
                 assert_eq!(ret.nonce, nonce);
 
                 let session = ret.payload;
-                assert_eq!(session.address, symbol.address);
+                assert_eq!(session.address, socket.address);
                 assert_eq!(session.username, username);
                 session
             };

--- a/turn-server.toml
+++ b/turn-server.toml
@@ -25,20 +25,20 @@ bind = "127.0.0.1:3478"
 # address and service listening port.
 external = "127.0.0.1:3478"
 #
-# [[turn.interfaces]]
-# transport = "tcp"
-# bind = "127.0.0.1:3478"
-# external = "127.0.0.1:3478"
-#
-# [[turn.interfaces]]
-# transport = "udp"
-# bind = "[::1]:3478"
-# external = "[::1]:3478"
-#
-# [[turn.interfaces]]
-# transport = "tcp"
-# bind = "[::1]:3478"
-# external = "[::1]:3478"
+[[turn.interfaces]]
+transport = "tcp"
+bind = "127.0.0.1:3478"
+external = "127.0.0.1:3478"
+
+[[turn.interfaces]]
+transport = "udp"
+bind = "[::1]:3478"
+external = "[::1]:3478"
+
+[[turn.interfaces]]
+transport = "tcp"
+bind = "[::1]:3478"
+external = "[::1]:3478"
 
 [api]
 # controller bind
@@ -88,6 +88,6 @@ level = "info"
 # The server will try to use static authentication first, and then use
 # external control service authentication.
 #
-# [auth.static_credentials]
-# user1 = "test"
-# user2 = "test"
+[auth.static_credentials]
+user1 = "test"
+user2 = "test"

--- a/turn-server.toml
+++ b/turn-server.toml
@@ -25,20 +25,20 @@ bind = "127.0.0.1:3478"
 # address and service listening port.
 external = "127.0.0.1:3478"
 #
-[[turn.interfaces]]
-transport = "tcp"
-bind = "127.0.0.1:3478"
-external = "127.0.0.1:3478"
+# [[turn.interfaces]]
+# transport = "tcp"
+# bind = "127.0.0.1:3478"
+# external = "127.0.0.1:3478"
 
-[[turn.interfaces]]
-transport = "udp"
-bind = "[::1]:3478"
-external = "[::1]:3478"
+# [[turn.interfaces]]
+# transport = "udp"
+# bind = "[::1]:3478"
+# external = "[::1]:3478"
 
-[[turn.interfaces]]
-transport = "tcp"
-bind = "[::1]:3478"
-external = "[::1]:3478"
+# [[turn.interfaces]]
+# transport = "tcp"
+# bind = "[::1]:3478"
+# external = "[::1]:3478"
 
 [api]
 # controller bind
@@ -88,6 +88,6 @@ level = "info"
 # The server will try to use static authentication first, and then use
 # external control service authentication.
 #
-[auth.static_credentials]
-user1 = "test"
-user2 = "test"
+# [auth.static_credentials]
+# user1 = "test"
+# user2 = "test"

--- a/turn-server/src/config.rs
+++ b/turn-server/src/config.rs
@@ -4,7 +4,6 @@ use anyhow::anyhow;
 use clap::Parser;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use stun::Transport as StunTransport;
 
 #[repr(C)]
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,24 +11,6 @@ use stun::Transport as StunTransport;
 pub enum Transport {
     TCP = 0,
     UDP = 1,
-}
-
-impl Into<StunTransport> for Transport {
-    fn into(self) -> StunTransport {
-        match self {
-            Self::TCP => StunTransport::TCP,
-            Self::UDP => StunTransport::UDP,
-        }
-    }
-}
-
-impl From<StunTransport> for Transport {
-    fn from(value: StunTransport) -> Self {
-        match value {
-            StunTransport::TCP => Self::TCP,
-            StunTransport::UDP => Self::UDP,
-        }
-    }
 }
 
 impl FromStr for Transport {

--- a/turn-server/src/router.rs
+++ b/turn-server/src/router.rs
@@ -3,9 +3,9 @@ use std::net::SocketAddr;
 use ahash::AHashMap;
 use parking_lot::RwLock;
 use tokio::sync::mpsc::*;
-use turn::StunClass;
+use turn::ResponseMethod;
 
-type Receiver = UnboundedSender<(Vec<u8>, StunClass, SocketAddr)>;
+type Receiver = UnboundedSender<(Vec<u8>, ResponseMethod, SocketAddr)>;
 
 /// Handles packet forwarding between transport protocols.
 #[derive(Default)]
@@ -14,16 +14,16 @@ pub struct Router {
 }
 
 impl Router {
-    /// Get the endpoint reader for the route.
+    /// Get the socket reader for the route.
     ///
-    /// Each transport protocol is layered according to its own endpoint, and
-    /// the data forwarded to this endpoint can be obtained by routing.
+    /// Each transport protocol is layered according to its own socket, and
+    /// the data forwarded to this socket can be obtained by routing.
     ///
     /// # Example
     ///
     /// ```
     /// use std::net::SocketAddr;
-    /// use turn::StunClass;
+    /// use turn::ResponseMethod;
     /// use turn_server::router::*;
     ///
     /// #[tokio::main]
@@ -32,17 +32,17 @@ impl Router {
     ///     let router = Router::default();
     ///     let mut receiver = router.get_receiver(addr);
     ///
-    ///     router.send(&addr, StunClass::Channel, &addr, &[1, 2, 3]);
+    ///     router.send(&addr, ResponseMethod::ChannelData, &addr, &[1, 2, 3]);
     ///     let ret = receiver.recv().await.unwrap();
     ///     assert_eq!(ret.0, vec![1, 2, 3]);
-    ///     assert_eq!(ret.1, StunClass::Channel);
+    ///     assert_eq!(ret.1, ResponseMethod::ChannelData);
     ///     assert_eq!(ret.2, addr);
     /// }
     /// ```
     pub fn get_receiver(
         &self,
         interface: SocketAddr,
-    ) -> UnboundedReceiver<(Vec<u8>, StunClass, SocketAddr)> {
+    ) -> UnboundedReceiver<(Vec<u8>, ResponseMethod, SocketAddr)> {
         let (sender, receiver) = unbounded_channel();
         self.senders.write().insert(interface, sender);
         receiver
@@ -50,16 +50,16 @@ impl Router {
 
     /// Send data to router.
     ///
-    /// By specifying the endpoint identifier and destination address, the route
-    /// is forwarded to the corresponding endpoint. However, it should be noted
-    /// that calling this function will not notify whether the endpoint exists.
+    /// By specifying the socket identifier and destination address, the route
+    /// is forwarded to the corresponding socket. However, it should be noted
+    /// that calling this function will not notify whether the socket exists.
     /// If it does not exist, the data will be discarded by default.
     ///
     /// # Example
     ///
     /// ```
     /// use std::net::SocketAddr;
-    /// use turn::StunClass;
+    /// use turn::ResponseMethod;
     /// use turn_server::router::*;
     ///
     /// #[tokio::main]
@@ -68,19 +68,25 @@ impl Router {
     ///     let router = Router::default();
     ///     let mut receiver = router.get_receiver(addr);
     ///
-    ///     router.send(&addr, StunClass::Channel, &addr, &[1, 2, 3]);
+    ///     router.send(&addr, ResponseMethod::ChannelData, &addr, &[1, 2, 3]);
     ///     let ret = receiver.recv().await.unwrap();
     ///     assert_eq!(ret.0, vec![1, 2, 3]);
-    ///     assert_eq!(ret.1, StunClass::Channel);
+    ///     assert_eq!(ret.1, ResponseMethod::ChannelData);
     ///     assert_eq!(ret.2, addr);
     /// }
     /// ```
-    pub fn send(&self, interface: &SocketAddr, class: StunClass, addr: &SocketAddr, data: &[u8]) {
+    pub fn send(
+        &self,
+        interface: &SocketAddr,
+        method: ResponseMethod,
+        addr: &SocketAddr,
+        data: &[u8],
+    ) {
         let mut is_destroy = false;
 
         {
             if let Some(sender) = self.senders.read().get(interface) {
-                if sender.send((data.to_vec(), class, *addr)).is_err() {
+                if sender.send((data.to_vec(), method, *addr)).is_err() {
                     is_destroy = true;
                 }
             }
@@ -91,13 +97,13 @@ impl Router {
         }
     }
 
-    /// delete endpoint.
+    /// delete socket.
     ///
     /// # Example
     ///
     /// ```
     /// use std::net::SocketAddr;
-    /// use turn::StunClass;
+    /// use turn::ResponseMethod;
     /// use turn_server::router::*;
     ///
     /// #[tokio::main]
@@ -106,10 +112,10 @@ impl Router {
     ///     let router = Router::default();
     ///     let mut receiver = router.get_receiver(addr);
     ///
-    ///     router.send(&addr, StunClass::Channel, &addr, &[1, 2, 3]);
+    ///     router.send(&addr, ResponseMethod::ChannelData, &addr, &[1, 2, 3]);
     ///     let ret = receiver.recv().await.unwrap();
     ///     assert_eq!(ret.0, vec![1, 2, 3]);
-    ///     assert_eq!(ret.1, StunClass::Channel);
+    ///     assert_eq!(ret.1, ResponseMethod::ChannelData);
     ///     assert_eq!(ret.2, addr);
     ///
     ///     router.remove(&addr);

--- a/turn/src/lib.rs
+++ b/turn/src/lib.rs
@@ -5,7 +5,7 @@ use self::operations::ServiceContext;
 
 pub use self::{
     operations::{Operationer, ResponseMethod},
-    sessions::{PortAllocatePools, Session, Sessions, Socket},
+    sessions::{PortAllocatePools, Session, Sessions, SessionAddr},
 };
 
 use std::{net::SocketAddr, sync::Arc};
@@ -21,7 +21,7 @@ static SOFTWARE: &str = concat!(
 #[allow(unused)]
 #[async_trait]
 pub trait Observer: Send + Sync {
-    async fn get_password(&self, socket: &Socket, username: &str) -> Option<String> {
+    async fn get_password(&self, addr: &SessionAddr, username: &str) -> Option<String> {
         None
     }
 
@@ -41,7 +41,7 @@ pub trait Observer: Send + Sync {
     /// server SHOULD NOT allocate ports in the range 0 - 1023 (the Well-
     /// Known Port range) to discourage clients from using TURN to run
     /// standard services.
-    fn allocated(&self, socket: &Socket, username: &str, port: u16) {}
+    fn allocated(&self, addr: &SessionAddr, username: &str, port: u16) {}
 
     /// channel binding request
     ///
@@ -73,7 +73,7 @@ pub trait Observer: Send + Sync {
     /// different channel, eliminating the possibility that the
     /// transaction would initially fail but succeed on a
     /// retransmission.
-    fn channel_bind(&self, socket: &Socket, username: &str, channel: u16) {}
+    fn channel_bind(&self, addr: &SessionAddr, username: &str, channel: u16) {}
 
     /// create permission request
     ///
@@ -114,7 +114,7 @@ pub trait Observer: Send + Sync {
     /// idempotency of CreatePermission requests over UDP using the
     /// "stateless stack approach".  Retransmitted CreatePermission
     /// requests will simply refresh the permissions.
-    fn create_permission(&self, socket: &Socket, username: &str, ports: &[u16]) {}
+    fn create_permission(&self, addr: &SessionAddr, username: &str, ports: &[u16]) {}
 
     /// refresh request
     ///
@@ -155,14 +155,14 @@ pub trait Observer: Send + Sync {
     /// will cause a 437 (Allocation Mismatch) response if the
     /// allocation has already been deleted, but the client will treat
     /// this as equivalent to a success response (see below).
-    fn refresh(&self, socket: &Socket, username: &str, lifetime: u32) {}
+    fn refresh(&self, addr: &SessionAddr, username: &str, lifetime: u32) {}
 
     /// session closed
     ///
     /// Triggered when the session leaves from the turn. Possible reasons: the
     /// session life cycle has expired, external active deletion, or active
     /// exit of the session.
-    fn closed(&self, socket: &Socket, username: &str) {}
+    fn closed(&self, addr: &SessionAddr, username: &str) {}
 }
 
 /// Turn service.

--- a/turn/src/operations/binding.rs
+++ b/turn/src/operations/binding.rs
@@ -1,5 +1,5 @@
-use super::{Requet, Response};
-use crate::{Observer, StunClass, SOFTWARE};
+use super::{Requet, Response, ResponseMethod};
+use crate::{Observer, SOFTWARE};
 
 use stun::{
     attribute::{MappedAddress, ResponseOrigin, Software, XorMappedAddress},
@@ -33,18 +33,17 @@ pub fn process<'a, T: Observer>(req: Requet<'_, 'a, T, MessageReader<'_>>) -> Op
         let mut message =
             MessageWriter::extend(Method::Binding(Kind::Response), &req.message, req.bytes);
 
-        message.append::<XorMappedAddress>(req.symbol.address);
-        message.append::<MappedAddress>(req.symbol.address);
-        message.append::<ResponseOrigin>(req.service.external);
+        message.append::<XorMappedAddress>(req.socket.address);
+        message.append::<MappedAddress>(req.socket.address);
+        message.append::<ResponseOrigin>(req.service.interface);
         message.append::<Software>(SOFTWARE);
         message.flush(None).ok()?;
     }
 
     Some(Response {
-        kind: StunClass::Message,
+        method: ResponseMethod::Stun(Method::Binding(Kind::Response)),
         bytes: req.bytes,
-        interface: None,
-        reject: false,
+        endpoint: None,
         relay: None,
     })
 }

--- a/turn/src/operations/binding.rs
+++ b/turn/src/operations/binding.rs
@@ -33,8 +33,8 @@ pub fn process<'a, T: Observer>(req: Requet<'_, 'a, T, MessageReader<'_>>) -> Op
         let mut message =
             MessageWriter::extend(Method::Binding(Kind::Response), &req.message, req.bytes);
 
-        message.append::<XorMappedAddress>(req.socket.address);
-        message.append::<MappedAddress>(req.socket.address);
+        message.append::<XorMappedAddress>(req.address.address);
+        message.append::<MappedAddress>(req.address.address);
         message.append::<ResponseOrigin>(req.service.interface);
         message.append::<Software>(SOFTWARE);
         message.flush(None).ok()?;

--- a/turn/src/operations/channel_bind.rs
+++ b/turn/src/operations/channel_bind.rs
@@ -108,13 +108,13 @@ pub async fn process<'a, T: Observer>(
     if !req
         .service
         .sessions
-        .bind_channel(&req.socket, &req.service.endpoint, peer.port(), number)
+        .bind_channel(&req.address, &req.service.endpoint, peer.port(), number)
     {
         return reject(req, ErrorKind::Forbidden);
     }
 
     req.service
         .observer
-        .channel_bind(&req.socket, username, number);
+        .channel_bind(&req.address, username, number);
     resolve(req, &digest)
 }

--- a/turn/src/operations/channel_data.rs
+++ b/turn/src/operations/channel_data.rs
@@ -1,5 +1,5 @@
-use super::{Requet, Response};
-use crate::{Observer, StunClass};
+use super::{Requet, Response, ResponseMethod};
+use crate::Observer;
 
 use stun::ChannelData;
 
@@ -38,17 +38,16 @@ pub fn process<'a, T: Observer>(
     let relay = req
         .service
         .sessions
-        .get_channel_relay_address(&req.symbol, req.message.number)?;
+        .get_channel_relay_address(&req.socket, req.message.number)?;
 
     Some(Response {
-        interface: if req.symbol.interface != relay.interface {
-            Some(relay.interface)
+        method: ResponseMethod::ChannelData,
+        endpoint: if req.service.endpoint != relay.endpoint {
+            Some(relay.endpoint)
         } else {
             None
         },
         relay: Some(relay.address),
-        kind: StunClass::Channel,
-        reject: false,
         bytes,
     })
 }

--- a/turn/src/operations/channel_data.rs
+++ b/turn/src/operations/channel_data.rs
@@ -38,7 +38,7 @@ pub fn process<'a, T: Observer>(
     let relay = req
         .service
         .sessions
-        .get_channel_relay_address(&req.socket, req.message.number)?;
+        .get_channel_relay_address(&req.address, req.message.number)?;
 
     Some(Response {
         method: ResponseMethod::ChannelData,

--- a/turn/src/operations/create_permission.rs
+++ b/turn/src/operations/create_permission.rs
@@ -116,13 +116,13 @@ pub async fn process<'a, T: Observer>(
     if !req
         .service
         .sessions
-        .create_permission(&req.socket, &req.service.endpoint, &ports)
+        .create_permission(&req.address, &req.service.endpoint, &ports)
     {
         return reject(req, ErrorKind::Forbidden);
     }
 
     req.service
         .observer
-        .create_permission(&req.socket, username, &ports);
+        .create_permission(&req.address, username, &ports);
     resolve(req, &digest)
 }

--- a/turn/src/operations/indication.rs
+++ b/turn/src/operations/indication.rs
@@ -59,12 +59,12 @@ pub fn process<'a, T: Observer>(req: Requet<'_, 'a, T, MessageReader<'_>>) -> Op
     let relay = req
         .service
         .sessions
-        .get_relay_address(&req.socket, peer.port())?;
+        .get_relay_address(&req.address, peer.port())?;
 
     let local_port = req
         .service
         .sessions
-        .get_session(&req.socket)
+        .get_session(&req.address)
         .get_ref()?
         .allocate
         .port?;

--- a/turn/src/operations/refresh.rs
+++ b/turn/src/operations/refresh.rs
@@ -98,12 +98,12 @@ pub async fn process<'a, T: Observer>(
     };
 
     let lifetime = req.message.get::<Lifetime>().unwrap_or(600);
-    if !req.service.sessions.refresh(&req.socket, lifetime) {
+    if !req.service.sessions.refresh(&req.address, lifetime) {
         return reject(req, ErrorKind::AllocationMismatch);
     }
 
     req.service
         .observer
-        .refresh(&req.socket, username, lifetime);
+        .refresh(&req.address, username, lifetime);
     resolve(req, lifetime, &digest)
 }


### PR DESCRIPTION
- Fix: Change the names of types that are not semantically clear.
- Fix: The session identifier does not require a transport protocol type, only the address and interface are retained.
- Fix: The interface parameters passed by the external api are incorrect and not the real interface.
- Fix: The external api query parameter does not need to specify the transport type.