### PR TITLE
Implement programmatic shut down and monitoring of the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1440,17 +1440,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime 0.7.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.13",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1458,12 +1455,6 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
@@ -1475,24 +1466,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.8",
- "winnow 0.6.20",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
-dependencies = [
- "winnow 0.7.13",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -1851,12 +1829,6 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 simple_logger = "5"
 tokio = { version = "1", features = ["full"] }
-toml = "0.9"
+toml = "0.8"
 rand = "0.9"
 itertools = "0.14"
 prometheus = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 
 use self::{config::Config, observer::Observer, statistics::Statistics, turn::Service};
 
+// Re-export ServerHandle for external use
+pub use server::ServerHandle;
+
 #[rustfmt::skip]
 static SOFTWARE: &str = concat!(
     "turn-rs.",
@@ -21,6 +24,21 @@ static SOFTWARE: &str = concat!(
 /// start the server, a function is opened to replace the main function to
 /// directly start the server.
 pub async fn startup(config: Arc<Config>) -> anyhow::Result<()> {
+    let _server_handle = startup_with_handle(config).await?;
+
+    // The turn server is non-blocking after it runs and needs to be kept from
+    // exiting immediately if the api server is not enabled.
+    #[cfg(not(feature = "api"))]
+    {
+        _server_handle.wait_for_shutdown().await?;
+    }
+
+    Ok(())
+}
+
+/// Start the server and return a handle for controlling it.
+/// This allows external code to manage server lifecycle.
+pub async fn startup_with_handle(config: Arc<Config>) -> anyhow::Result<ServerHandle> {
     let statistics = Statistics::default();
     let service = Service::new(
         SOFTWARE.to_string(),
@@ -29,19 +47,12 @@ pub async fn startup(config: Arc<Config>) -> anyhow::Result<()> {
         Observer::new(config.clone(), statistics.clone()).await?,
     );
 
-    server::start(&config, &statistics, &service).await?;
+    let server_handle = server::start(&config, &statistics, &service).await?;
 
     #[cfg(feature = "api")]
     {
         api::start_server(config, service, statistics).await?;
     }
 
-    // The turn server is non-blocking after it runs and needs to be kept from
-    // exiting immediately if the api server is not enabled.
-    #[cfg(not(feature = "api"))]
-    {
-        std::future::pending::<()>().await;
-    }
-
-    Ok(())
+    Ok(server_handle)
 }


### PR DESCRIPTION
If used as an API within a program that cannot simply be shut down completely to exit the service, and that needs to keep track of the running status of the server, a handle is desirable. Tests still pass.