### PR TITLE
fix(channel): forward channel data as DATA-INDICATION and key relay t…

### DIFF
--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -192,15 +192,12 @@ where
         }
 
         Ok(match self.decoder.decode(bytes)? {
-            DecodeResult::ChannelData(channel) => channel_data(
-                bytes,
-                Request {
-                    id: &self.current_id,
-                    state: &self.state,
-                    encode_buffer: &mut self.bytes,
-                    payload: &channel,
-                },
-            ),
+            DecodeResult::ChannelData(channel) => channel_data(Request {
+                id: &self.current_id,
+                state: &self.state,
+                encode_buffer: &mut self.bytes,
+                payload: &channel,
+            }),
             DecodeResult::Message(message) => {
                 let req = Request {
                     id: &self.current_id,
@@ -675,10 +672,7 @@ where
 /// the Length field in the ChannelData message is 0, then there will be
 /// no data in the UDP datagram, but the UDP datagram is still formed and
 /// sent [(Section 4.1 of [RFC6263])](https://tools.ietf.org/html/rfc6263#section-4.1).
-fn channel_data<'a, T>(
-    bytes: &'a [u8],
-    req: Request<'_, 'a, T, ChannelData<'_>>,
-) -> Option<Response<'a>>
+fn channel_data<'a, T>(req: Request<'_, 'a, T, ChannelData<'_>>) -> Option<Response<'a>>
 where
     T: ServiceHandler,
 {
@@ -687,8 +681,32 @@ where
         .manager
         .get_channel_relay_address(req.id, req.payload.number())?;
 
+    let local_port = {
+        let lock = req.state.manager.get_session(req.id);
+        match lock.get_ref()? {
+            Session::Authenticated {
+                allocate_port: Some(port),
+                ..
+            } => *port,
+            _ => return None,
+        }
+    };
+
+    {
+        let transaction_id: [u8; 12] = rand::random();
+        let mut message =
+            MessageEncoder::new(DATA_INDICATION, &transaction_id, req.encode_buffer);
+        message.append::<XorPeerAddress>(SocketAddr::new(
+            req.state.interface.ip(),
+            local_port,
+        ));
+        message.append::<Data>(req.payload.bytes());
+        message.flush(None).ok()?;
+    }
+
     Some(Response {
-        bytes,
+        method: Some(DATA_INDICATION),
+        bytes: req.encode_buffer,
         target: Target {
             relay: Some(relay.source()),
             endpoint: if req.state.endpoint != relay.endpoint() {
@@ -697,6 +715,5 @@ where
                 None
             },
         },
-        method: None,
     })
 }

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -681,6 +681,30 @@ where
         .manager
         .get_channel_relay_address(req.id, req.payload.number())?;
 
+    let peer_id = Identifier::new(relay.source(), req.id.interface());
+    let peer_channel = req
+        .state
+        .manager
+        .find_peer_channel(&peer_id, req.id.source());
+
+    let target = Target {
+        relay: Some(relay.source()),
+        endpoint: if req.state.endpoint != relay.endpoint() {
+            Some(relay.endpoint())
+        } else {
+            None
+        },
+    };
+
+    if let Some(channel) = peer_channel {
+        ChannelData::new(channel, req.payload.bytes()).encode(req.encode_buffer);
+        return Some(Response {
+            method: None,
+            bytes: req.encode_buffer,
+            target,
+        });
+    }
+
     let local_port = {
         let lock = req.state.manager.get_session(req.id);
         match lock.get_ref()? {
@@ -692,28 +716,15 @@ where
         }
     };
 
-    {
-        let transaction_id: [u8; 12] = rand::random();
-        let mut message =
-            MessageEncoder::new(DATA_INDICATION, &transaction_id, req.encode_buffer);
-        message.append::<XorPeerAddress>(SocketAddr::new(
-            req.state.interface.ip(),
-            local_port,
-        ));
-        message.append::<Data>(req.payload.bytes());
-        message.flush(None).ok()?;
-    }
+    let transaction_id: [u8; 12] = rand::random();
+    let mut message = MessageEncoder::new(DATA_INDICATION, &transaction_id, req.encode_buffer);
+    message.append::<XorPeerAddress>(SocketAddr::new(req.state.interface.ip(), local_port));
+    message.append::<Data>(req.payload.bytes());
+    message.flush(None).ok()?;
 
     Some(Response {
         method: Some(DATA_INDICATION),
         bytes: req.encode_buffer,
-        target: Target {
-            relay: Some(relay.source()),
-            endpoint: if req.state.endpoint != relay.endpoint() {
-                Some(relay.endpoint())
-            } else {
-                None
-            },
-        },
+        target,
     })
 }

--- a/src/service/session/mod.rs
+++ b/src/service/session/mod.rs
@@ -986,6 +986,15 @@ where
             .copied()
     }
 
+    pub fn find_peer_channel(&self, peer: &Identifier, target: SocketAddr) -> Option<u16> {
+        let table = self.channel_relay_table.read();
+        let peer_map = table.get(peer)?;
+        peer_map
+            .iter()
+            .find(|(_, ep)| ep.source() == target)
+            .map(|(ch, _)| *ch)
+    }
+
     /// Get the address of the port binding.
     ///
     /// # Test

--- a/src/service/session/mod.rs
+++ b/src/service/session/mod.rs
@@ -892,13 +892,13 @@ where
         // Create channel forwarding mapping relationships for peers.
         self.channel_relay_table
             .write()
-            .entry(peer)
+            .entry(*identifier)
             .or_insert_with(|| HashMap::with_capacity(10))
             .insert(
                 channel,
                 Endpoint {
-                    source: identifier.source,
-                    endpoint: *endpoint,
+                    source: peer.source(),
+                    endpoint: peer.source(),
                 },
             );
 
@@ -963,7 +963,7 @@ where
     ///         .get_channel_relay_address(&identifier, 0x4000)
     ///         .unwrap()
     ///         .endpoint(),
-    ///     endpoint
+    ///     peer_identifier.source()
     /// );
     ///
     /// assert_eq!(
@@ -971,7 +971,7 @@ where
     ///         .get_channel_relay_address(&peer_identifier, 0x4000)
     ///         .unwrap()
     ///         .endpoint(),
-    ///     endpoint
+    ///     identifier.source()
     /// );
     /// ```
     pub fn get_channel_relay_address(


### PR DESCRIPTION
I ran into an issue where relayed data silently drops between two clients.

The Issues

Dropped Frames: The server was forwarding ChannelData frames as-is. Because channel numbers are private to each user's connection, the receiving peer didn't recognize the sender's channel ID and silently dropped the frame.

Lookup Bug: In bind_channel, the internal lookup table was keyed by the peer, but channel_data was looking it up by the binder, resulting in failed lookups.

channel_data: Now re-encodes the payload as a DATA-INDICATION before forwarding, setting the sender's relay address in XOR-PEER-ADDRESS. This allows the peer's client to correctly identify the source and pass it to the application.

bind_channel: Now stores the entry under the binder's identifier (with the peer's address as the target) so lookups succeed.

Impact: Fixes relay failures for client-to-client connections on the same server. Direct P2P and STUN paths are completely unaffected.