### PR TITLE
feat: add embeddable RFC 8656 TURN runtime for OxideSFU testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,15 @@ This section explains how the server is organized internally and how the main da
 - optional Prometheus exporter via [src/prometheus.rs](src/prometheus.rs)
 - optional gRPC API via [src/api.rs](src/api.rs)
 
+Embedders can instead use `spawn_server_with_handler()` to supply their own
+`ServiceHandler` and own graceful shutdown through `ServerHandle`.
+
 ### Core modules
 
 1) [src/service](src/service): TURN service core, shared state, and routing glue.
 
 - `Service` holds realm, interfaces, session manager, and handler, and creates per-connection routers.
-- `ServiceHandler` defines the hooks the protocol layer uses for auth and lifecycle callbacks.
+- `ServiceHandler` defines the hooks the protocol layer uses for auth, pre-permission peer authorization, and lifecycle callbacks.
 - [src/service/routing.rs](src/service/routing.rs) parses STUN/TURN messages and dispatches by method.
 
 2) [src/service/session](src/service/session): Session state, allocation, permissions, and channel bindings.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For detailed information, please read directly the documentation: [AGENTS.md](./
 
 -   [features](#features)
 -   [usage](#usage)
+    -   [embedding](#embedding)
     -   [docker](#docker)
     -   [linux service](#linux-service)
 -   [building](#building)
@@ -85,6 +86,22 @@ turn-server --config=/etc/turn-server/config.toml
 ```
 
 Please check the example configuration file for details: [turn-server.toml](./turn-server.toml)
+
+### Embedding
+
+Applications that need their own authentication or peer-permission policy can
+provide a [`ServiceHandler`](./src/service/mod.rs) and own the runtime
+lifecycle directly:
+
+```rust
+let server = turn_server::spawn_server_with_handler(config, handler).await?;
+
+// Later, during application shutdown:
+server.shutdown().await?;
+```
+
+`ServiceHandler::allows_peer` runs before TURN permissions and channel bindings
+are installed. Returning `false` produces a TURN `403 Forbidden` response.
 
 #### Docker
 

--- a/sdk/protos/server.proto
+++ b/sdk/protos/server.proto
@@ -46,6 +46,17 @@ message TurnServerInfo {
     uint32 port_allocated = 5;
 }
 
+// RFC 8656 peer permission.
+message PeerPermission {
+    string peer_ip = 1;
+}
+
+// RFC 8656 channel binding.
+message PeerChannelBinding {
+    uint32 channel = 1;
+    string peer = 2;
+}
+
 // turn session
 message TurnSession {
     string username = 1;
@@ -55,8 +66,12 @@ message TurnSession {
     int64 expires = 3;
     // permissions port bind addresses
     repeated BindAddress permissions = 4;
-    // channels number bind addresses
+    // channels number bind addresses. Deprecated: cannot represent RFC 8656 peers.
     repeated BindAddress channels = 5;
+    // RFC 8656 permissions keyed by peer IP address.
+    repeated PeerPermission peer_permissions = 6;
+    // RFC 8656 channel bindings keyed by channel number and full peer address.
+    repeated PeerChannelBinding peer_channels = 7;
 }
 
 // turn session statistics

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -229,7 +229,8 @@ impl TurnService {
 
     /// destroy the session
     pub async fn destroy_session(&mut self, id: Identifier) -> Result<(), Status> {
-        Ok(self.0.destroy_session(Request::new(id)).await?.into_inner())
+        self.0.destroy_session(Request::new(id)).await?.into_inner();
+        Ok(())
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -134,8 +134,8 @@ impl TurnService for RpcService {
         if let Some(Session::Authenticated {
             username,
             allocated_port,
-            channel_relay_table,
-            port_relay_table,
+            channels,
+            permissions,
             expires,
             ..
         }) = self
@@ -151,18 +151,22 @@ impl TurnService for RpcService {
                 username: username.to_string(),
                 allocated_port: allocated_port.map(|p| p as i32),
                 expires: *expires as i64,
-                permissions: port_relay_table
-                    .iter()
-                    .map(|(k, v)| BindAddress {
-                        key: *k as i32,
-                        value: Some(v.clone().into()),
+                // The legacy management protobuf can only represent a TURN
+                // client identifier, not an RFC 8656 peer address. Keep the
+                // peer port as the key for channel bindings and leave the
+                // obsolete identifier field unset.
+                permissions: permissions
+                    .keys()
+                    .map(|_| BindAddress {
+                        key: 0,
+                        value: None,
                     })
                     .collect(),
-                channels: channel_relay_table
+                channels: channels
                     .iter()
-                    .map(|(k, v)| BindAddress {
-                        key: *k as i32,
-                        value: Some(v.clone().into()),
+                    .map(|(number, _)| BindAddress {
+                        key: *number as i32,
+                        value: None,
                     })
                     .collect(),
             }))

--- a/src/api.rs
+++ b/src/api.rs
@@ -224,6 +224,92 @@ impl TurnService for RpcService {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, time::Instant};
+
+    use super::*;
+    use crate::{
+        config::Config,
+        handler::Handler,
+        service::{Service, ServiceOptions, Transport, session::Identifier},
+    };
+
+    #[tokio::test]
+    async fn get_session_exposes_rfc_8656_peer_state() {
+        let mut config = Config::default();
+        config
+            .auth
+            .static_credentials
+            .insert("user".to_string(), "password".to_string());
+        let statistics = Statistics::default();
+        let service = Service::new(ServiceOptions {
+            realm: config.server.realm.clone(),
+            port_range: config.server.port_range,
+            interfaces: config.server.get_interface_addrs(),
+            handler: Handler::new(config.clone(), statistics.clone())
+                .await
+                .expect("test handler should initialize"),
+        });
+        let client = Identifier {
+            source: "127.0.0.1:50000"
+                .parse()
+                .expect("test client address should parse"),
+            interface: "127.0.0.1:3478"
+                .parse()
+                .expect("test interface address should parse"),
+            external: "127.0.0.1:3478"
+                .parse()
+                .expect("test external address should parse"),
+            transport: Transport::Udp,
+        };
+        let peer: SocketAddr = "127.0.0.1:50001"
+            .parse()
+            .expect("test peer address should parse");
+        let service_for_manager = service.clone();
+        let manager = service_for_manager.get_session_manager();
+
+        manager
+            .get_password(
+                &client,
+                "user",
+                crate::codec::message::attributes::PasswordAlgorithm::Md5,
+            )
+            .await
+            .expect("test client should authenticate");
+        manager
+            .allocate(&client, None)
+            .expect("test client should allocate");
+        assert!(manager.create_permission(&client, &[peer]));
+        assert!(manager.bind_channel(&client, peer, 0x4000));
+
+        let rpc = RpcService {
+            config,
+            service,
+            statistics,
+            uptime: Instant::now(),
+        };
+        let response = rpc
+            .get_session(Request::new(client.into()))
+            .await
+            .expect("authenticated session should be available")
+            .into_inner();
+
+        assert_eq!(response.peer_permissions.len(), 1);
+        assert_eq!(response.peer_permissions[0].peer_ip, "127.0.0.1");
+        assert_eq!(response.peer_channels.len(), 1);
+        assert_eq!(response.peer_channels[0].channel, 0x4000);
+        assert_eq!(response.peer_channels[0].peer, peer.to_string());
+
+        assert!(manager.refresh(&client, 0));
+        let status = rpc
+            .get_session(Request::new(client.into()))
+            .await
+            .expect_err("allocation teardown should remove management state");
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+}
+
 pub enum HooksEvent {
     Allocated(TurnAllocatedEvent),
     ChannelBind(TurnChannelBindEvent),

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,9 +23,9 @@ use tonic::{
 use tonic::transport::{Certificate, ClientTlsConfig, Identity, ServerTlsConfig};
 
 use sdk::protos::{
-    BindAddress, GetTurnPasswordRequest, TurnAllocatedEvent, TurnChannelBindEvent,
-    TurnCreatePermissionEvent, TurnDestroyEvent, TurnRefreshEvent, TurnServerInfo, TurnSession,
-    TurnSessionStatistics,
+    BindAddress, GetTurnPasswordRequest, PeerChannelBinding, PeerPermission, TurnAllocatedEvent,
+    TurnChannelBindEvent, TurnCreatePermissionEvent, TurnDestroyEvent, TurnRefreshEvent,
+    TurnServerInfo, TurnSession, TurnSessionStatistics,
     turn_hooks_service_client::TurnHooksServiceClient,
     turn_service_server::{TurnService, TurnServiceServer},
 };
@@ -167,6 +167,19 @@ impl TurnService for RpcService {
                     .map(|(number, _)| BindAddress {
                         key: *number as i32,
                         value: None,
+                    })
+                    .collect(),
+                peer_permissions: permissions
+                    .keys()
+                    .map(|peer_ip| PeerPermission {
+                        peer_ip: peer_ip.to_string(),
+                    })
+                    .collect(),
+                peer_channels: channels
+                    .iter()
+                    .map(|(number, binding)| PeerChannelBinding {
+                        channel: *number as u32,
+                        peer: binding.peer().to_string(),
                     })
                     .collect(),
             }))

--- a/src/codec/channel_data.rs
+++ b/src/codec/channel_data.rs
@@ -122,8 +122,23 @@ impl<'a> ChannelData<'a> {
         }
 
         Ok(Self {
-            bytes: &bytes[4..],
+            bytes: &bytes[4..4 + size],
             number,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChannelData;
+
+    #[test]
+    fn decode_ignores_trailing_channel_data_padding() {
+        let encoded = [0x40, 0x00, 0x00, 0x03, b'a', b'b', b'c', 0x00];
+
+        let channel_data = ChannelData::decode(&encoded).expect("channel data should decode");
+
+        assert_eq!(channel_data.number(), 0x4000);
+        assert_eq!(channel_data.bytes(), b"abc");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,17 @@ pub mod prelude {
     };
 }
 
-use self::{config::Config, handler::Handler, service::ServiceOptions, statistics::Statistics};
+use self::{
+    config::Config,
+    handler::Handler,
+    service::{ServiceHandler, ServiceOptions},
+    statistics::Statistics,
+};
 
-use tokio::task::JoinSet;
+use tokio::{
+    sync::watch,
+    task::{JoinHandle, JoinSet},
+};
 
 #[rustfmt::skip]
 pub(crate) static SOFTWARE: &str = concat!(
@@ -44,36 +52,167 @@ pub(crate) type Service = service::Service<Handler>;
 /// In order to let the integration test directly use the turn-server crate and
 /// start the server, a function is opened to replace the main function to
 /// directly start the server.
-pub async fn start_server(config: Config) -> anyhow::Result<()> {
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use super::{Config, spawn_server, spawn_server_with_handler};
+    use crate::{
+        codec::{crypto::Password, message::attributes::PasswordAlgorithm},
+        config::{Interface, Server},
+        service::{ServiceHandler, session::Identifier},
+    };
+
+    #[derive(Clone)]
+    struct AllowAllHandler;
+
+    impl ServiceHandler for AllowAllHandler {
+        async fn get_password(
+            &self,
+            _id: &Identifier,
+            _username: &str,
+            _algorithm: PasswordAlgorithm,
+        ) -> Option<Password> {
+            None
+        }
+    }
+
+    fn test_config() -> Config {
+        Config {
+            server: Server {
+                interfaces: vec![Interface::Udp {
+                    listen: "127.0.0.1:0"
+                        .parse::<SocketAddr>()
+                        .expect("test listen address should parse"),
+                    external: "127.0.0.1:0"
+                        .parse::<SocketAddr>()
+                        .expect("test external address should parse"),
+                    idle_timeout: 1,
+                    mtu: 1500,
+                }],
+                ..Server::default()
+            },
+            ..Config::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn spawned_server_stops_cleanly() {
+        spawn_server(test_config())
+            .await
+            .expect("server should start")
+            .shutdown()
+            .await
+            .expect("server should stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn custom_handler_server_stops_cleanly() {
+        spawn_server_with_handler(test_config(), AllowAllHandler)
+            .await
+            .expect("server should start")
+            .shutdown()
+            .await
+            .expect("server should stop cleanly");
+    }
+}
+
+/// Owns a spawned TURN server and provides graceful shutdown.
+pub struct ServerHandle {
+    shutdown: watch::Sender<bool>,
+    task: JoinHandle<anyhow::Result<()>>,
+}
+
+impl ServerHandle {
+    /// Stops the TURN server and waits for its listener tasks to exit.
+    pub async fn shutdown(self) -> anyhow::Result<()> {
+        let _ = self.shutdown.send(true);
+        self.task.await??;
+        Ok(())
+    }
+}
+
+async fn build_service(config: &Config, statistics: Statistics) -> anyhow::Result<Service> {
+    Ok(service::Service::new(ServiceOptions {
+        realm: config.server.realm.clone(),
+        port_range: config.server.port_range,
+        interfaces: config.server.get_interface_addrs(),
+        handler: Handler::new(config.clone(), statistics).await?,
+    }))
+}
+
+async fn run_server(
+    config: Config,
+    service: Service,
+    statistics: Statistics,
+    shutdown: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let mut workers = JoinSet::new();
+
+    workers.spawn(server::start_server(
+        config.clone(),
+        service.clone(),
+        statistics.clone(),
+        shutdown,
+    ));
+
+    #[cfg(feature = "prometheus")]
+    workers.spawn(prometheus::start_server(config.clone()));
+
+    #[cfg(feature = "api")]
+    workers.spawn(api::start_server(config, service, statistics));
+
+    if let Some(result) = workers.join_next().await {
+        workers.abort_all();
+        return result?;
+    }
+
+    Ok(())
+}
+
+/// Starts a TURN server in a background task and returns its lifecycle handle.
+pub async fn spawn_server(config: Config) -> anyhow::Result<ServerHandle> {
+    let statistics = Statistics::default();
+    let service = build_service(&config, statistics.clone()).await?;
+    let (shutdown, shutdown_rx) = watch::channel(false);
+    let task = tokio::spawn(run_server(config, service, statistics, shutdown_rx));
+
+    Ok(ServerHandle { shutdown, task })
+}
+
+/// Starts a TURN server with an application-provided authentication and peer-policy handler.
+///
+/// This entry point runs only the TURN transport runtime; callers own any management
+/// API and metrics services they need alongside it.
+pub async fn spawn_server_with_handler<T>(
+    config: Config,
+    handler: T,
+) -> anyhow::Result<ServerHandle>
+where
+    T: ServiceHandler + Clone,
+{
     let statistics = Statistics::default();
     let service = service::Service::new(ServiceOptions {
         realm: config.server.realm.clone(),
         port_range: config.server.port_range,
         interfaces: config.server.get_interface_addrs(),
-        handler: Handler::new(config.clone(), statistics.clone()).await?,
+        handler,
     });
+    let (shutdown, shutdown_rx) = watch::channel(false);
+    let task = tokio::spawn(server::start_server(
+        config,
+        service,
+        statistics,
+        shutdown_rx,
+    ));
 
-    {
-        let mut workers = JoinSet::new();
+    Ok(ServerHandle { shutdown, task })
+}
 
-        workers.spawn(server::start_server(
-            config.clone(),
-            service.clone(),
-            statistics.clone(),
-        ));
-
-        #[cfg(feature = "prometheus")]
-        workers.spawn(prometheus::start_server(config.clone()));
-
-        #[cfg(feature = "api")]
-        workers.spawn(api::start_server(config, service, statistics));
-
-        if let Some(res) = workers.join_next().await {
-            workers.abort_all();
-
-            return res?;
-        }
-    }
-
-    Ok(())
+/// Starts a TURN server and waits until it exits.
+pub async fn start_server(config: Config) -> anyhow::Result<()> {
+    let statistics = Statistics::default();
+    let service = build_service(&config, statistics.clone()).await?;
+    let (_shutdown, shutdown_rx) = watch::channel(false);
+    run_server(config, service, statistics, shutdown_rx).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use self::{
 };
 
 use tokio::{
-    sync::watch,
+    sync::{oneshot, watch},
     task::{JoinHandle, JoinSet},
 };
 
@@ -115,6 +115,29 @@ mod tests {
             .await
             .expect("server should stop cleanly");
     }
+
+    #[tokio::test]
+    async fn spawn_reports_listener_bind_failure() {
+        let occupied_socket =
+            std::net::UdpSocket::bind("127.0.0.1:0").expect("test socket should bind");
+        let mut config = test_config();
+        let occupied_address = occupied_socket
+            .local_addr()
+            .expect("test socket should have a local address");
+        config.server.interfaces = vec![Interface::Udp {
+            listen: occupied_address,
+            external: occupied_address,
+            idle_timeout: 1,
+            mtu: 1500,
+        }];
+
+        let error = match spawn_server_with_handler(config, AllowAllHandler).await {
+            Ok(_) => panic!("spawn should return the listener bind failure"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("Address already in use"));
+    }
 }
 
 /// Owns a spawned TURN server and provides graceful shutdown.
@@ -146,6 +169,7 @@ async fn run_server(
     service: Service,
     statistics: Statistics,
     shutdown: watch::Receiver<bool>,
+    startup: Option<oneshot::Sender<anyhow::Result<()>>>,
 ) -> anyhow::Result<()> {
     let mut workers = JoinSet::new();
 
@@ -154,6 +178,7 @@ async fn run_server(
         service.clone(),
         statistics.clone(),
         shutdown,
+        startup,
     ));
 
     #[cfg(feature = "prometheus")]
@@ -175,9 +200,28 @@ pub async fn spawn_server(config: Config) -> anyhow::Result<ServerHandle> {
     let statistics = Statistics::default();
     let service = build_service(&config, statistics.clone()).await?;
     let (shutdown, shutdown_rx) = watch::channel(false);
-    let task = tokio::spawn(run_server(config, service, statistics, shutdown_rx));
+    let (startup_sender, startup_receiver) = oneshot::channel();
+    let task = tokio::spawn(run_server(
+        config,
+        service,
+        statistics,
+        shutdown_rx,
+        Some(startup_sender),
+    ));
 
-    Ok(ServerHandle { shutdown, task })
+    match startup_receiver.await {
+        Ok(Ok(())) => Ok(ServerHandle { shutdown, task }),
+        Ok(Err(error)) => {
+            let _ = task.await;
+            Err(error)
+        }
+        Err(_) => {
+            let result = task.await?;
+            Err(result
+                .err()
+                .unwrap_or_else(|| anyhow::anyhow!("TURN server exited before startup")))
+        }
+    }
 }
 
 /// Starts a TURN server with an application-provided authentication and peer-policy handler.
@@ -199,14 +243,28 @@ where
         handler,
     });
     let (shutdown, shutdown_rx) = watch::channel(false);
+    let (startup_sender, startup_receiver) = oneshot::channel();
     let task = tokio::spawn(server::start_server(
         config,
         service,
         statistics,
         shutdown_rx,
+        Some(startup_sender),
     ));
 
-    Ok(ServerHandle { shutdown, task })
+    match startup_receiver.await {
+        Ok(Ok(())) => Ok(ServerHandle { shutdown, task }),
+        Ok(Err(error)) => {
+            let _ = task.await;
+            Err(error)
+        }
+        Err(_) => {
+            let result = task.await?;
+            Err(result
+                .err()
+                .unwrap_or_else(|| anyhow::anyhow!("TURN server exited before startup")))
+        }
+    }
 }
 
 /// Starts a TURN server and waits until it exits.
@@ -214,5 +272,5 @@ pub async fn start_server(config: Config) -> anyhow::Result<()> {
     let statistics = Statistics::default();
     let service = build_service(&config, statistics.clone()).await?;
     let (_shutdown, shutdown_rx) = watch::channel(false);
-    run_server(config, service, statistics, shutdown_rx).await
+    run_server(config, service, statistics, shutdown_rx, None).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shutdown_releases_listener_port() {
+        let reserved_socket =
+            std::net::UdpSocket::bind("127.0.0.1:0").expect("test socket should bind");
+        let address = reserved_socket
+            .local_addr()
+            .expect("test socket should have a local address");
+        drop(reserved_socket);
+
+        let mut config = test_config();
+        config.server.interfaces = vec![Interface::Udp {
+            listen: address,
+            external: address,
+            idle_timeout: 1,
+            mtu: 1500,
+        }];
+
+        spawn_server_with_handler(config, AllowAllHandler)
+            .await
+            .expect("server should bind the reserved port")
+            .shutdown()
+            .await
+            .expect("server should stop cleanly");
+
+        std::net::UdpSocket::bind(address).expect("shutdown should release the listener port");
+    }
+
+    #[tokio::test]
     async fn spawn_reports_listener_bind_failure() {
         let occupied_socket =
             std::net::UdpSocket::bind("127.0.0.1:0").expect("test socket should bind");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,10 @@ mod buffer;
 mod switch;
 
 use anyhow::Result;
-use tokio::{sync::watch, task::JoinSet};
+use tokio::{
+    sync::{mpsc::unbounded_channel, oneshot, watch},
+    task::JoinSet,
+};
 
 use self::switch::Switch;
 use crate::{
@@ -19,6 +22,7 @@ pub async fn start_server<T>(
     service: Service<T>,
     statistics: Statistics,
     shutdown: watch::Receiver<bool>,
+    startup: Option<oneshot::Sender<Result<()>>>,
 ) -> Result<()>
 where
     T: ServiceHandler + Clone,
@@ -26,6 +30,8 @@ where
     let switch = Switch::default();
 
     let mut servers = JoinSet::new();
+    let interface_count = config.server.interfaces.len();
+    let (startup_sender, mut startup_receiver) = unbounded_channel();
 
     for interface in config.server.interfaces {
         match interface {
@@ -48,6 +54,7 @@ where
                     statistics.clone(),
                     switch.clone(),
                     shutdown.clone(),
+                    startup_sender.clone(),
                 ));
             }
             Interface::Tcp {
@@ -69,9 +76,35 @@ where
                     statistics.clone(),
                     switch.clone(),
                     shutdown.clone(),
+                    startup_sender.clone(),
                 ));
             }
         };
+    }
+
+    drop(startup_sender);
+    let startup_result = async {
+        for _ in 0..interface_count {
+            startup_receiver.recv().await.ok_or_else(|| {
+                anyhow::anyhow!("TURN listener exited before reporting startup")
+            })??;
+        }
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    if let Some(startup) = startup {
+        let _ = startup.send(
+            startup_result
+                .as_ref()
+                .map(|_| ())
+                .map_err(|error| anyhow::anyhow!(error.to_string())),
+        );
+    }
+
+    if let Err(error) = startup_result {
+        servers.abort_all();
+        return Err(error);
     }
 
     // As soon as one server exits, all servers will be exited to ensure the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,18 +4,25 @@ mod buffer;
 mod switch;
 
 use anyhow::Result;
-use tokio::task::JoinSet;
+use tokio::{sync::watch, task::JoinSet};
 
 use self::switch::Switch;
 use crate::{
-    Service,
     config::{Config, Interface},
     server::provider::{ProviderServer, ServerOptions, tcp::TcpServer, udp::UdpServer},
-    service::Transport,
+    service::{Service, ServiceHandler, Transport},
     statistics::Statistics,
 };
 
-pub async fn start_server(config: Config, service: Service, statistics: Statistics) -> Result<()> {
+pub async fn start_server<T>(
+    config: Config,
+    service: Service<T>,
+    statistics: Statistics,
+    shutdown: watch::Receiver<bool>,
+) -> Result<()>
+where
+    T: ServiceHandler + Clone,
+{
     let switch = Switch::default();
 
     let mut servers = JoinSet::new();
@@ -40,6 +47,7 @@ pub async fn start_server(config: Config, service: Service, statistics: Statisti
                     service.clone(),
                     statistics.clone(),
                     switch.clone(),
+                    shutdown.clone(),
                 ));
             }
             Interface::Tcp {
@@ -60,6 +68,7 @@ pub async fn start_server(config: Config, service: Service, statistics: Statisti
                     service.clone(),
                     statistics.clone(),
                     switch.clone(),
+                    shutdown.clone(),
                 ));
             }
         };

--- a/src/server/provider/mod.rs
+++ b/src/server/provider/mod.rs
@@ -4,7 +4,10 @@ pub mod udp;
 use std::{net::SocketAddr, ops::DerefMut, task::Poll, time::Duration};
 
 use anyhow::Result;
-use tokio::{sync::watch, time::interval};
+use tokio::{
+    sync::{mpsc::UnboundedSender, watch},
+    time::interval,
+};
 
 use crate::{
     codec::{
@@ -59,6 +62,7 @@ pub trait ProviderServer: Sized + Send {
         statistics: Statistics,
         switch: Switch,
         shutdown: watch::Receiver<bool>,
+        startup: UnboundedSender<Result<()>>,
     ) -> impl Future<Output = Result<()>> + Send
     where
         T: ServiceHandler + Clone,
@@ -67,8 +71,21 @@ pub trait ProviderServer: Sized + Send {
         let idle_timeout = options.idle_timeout as u64;
 
         async move {
-            let mut listener = Self::bind(&options, shutdown.clone()).await?;
-            let local_addr = listener.local_addr()?;
+            let mut listener = match Self::bind(&options, shutdown.clone()).await {
+                Ok(listener) => listener,
+                Err(error) => {
+                    let _ = startup.send(Err(anyhow::anyhow!(error.to_string())));
+                    return Err(error);
+                }
+            };
+            let local_addr = match listener.local_addr() {
+                Ok(local_addr) => local_addr,
+                Err(error) => {
+                    let _ = startup.send(Err(anyhow::anyhow!(error.to_string())));
+                    return Err(error);
+                }
+            };
+            let _ = startup.send(Ok(()));
             let mut shutdown = shutdown;
 
             log::info!(

--- a/src/server/provider/mod.rs
+++ b/src/server/provider/mod.rs
@@ -1,15 +1,23 @@
 pub mod tcp;
 pub mod udp;
 
-use std::{net::SocketAddr, task::Poll, time::Duration};
+use std::{net::SocketAddr, ops::DerefMut, task::Poll, time::Duration};
 
 use anyhow::Result;
 use tokio::{sync::watch, time::interval};
 
 use crate::{
+    codec::{
+        channel_data::ChannelData,
+        message::{
+            MessageEncoder,
+            attributes::{Data, XorPeerAddress},
+            methods::DATA_INDICATION,
+        },
+    },
     config::Ssl,
     server::{Switch, buffer::Buffer},
-    service::{Service, ServiceHandler, Transport, session::Identifier},
+    service::{Service, ServiceHandler, Transport, routing::RelayTarget, session::Identifier},
     statistics::{Statistics, Stats},
 };
 
@@ -117,34 +125,68 @@ pub trait ProviderServer: Sized + Send {
                                 if let Ok(Some(res)) = router.route(&buffer, &mut response_buffer).await
                                 {
 
-                                    if let Some(relay) = res.relay {
-                                        // The channel data needs to be aligned in multiples of 4 in
-                                        // tcp. If the channel data is forwarded to tcp, the alignment
-                                        // bit needs to be filled, because if the channel data comes
-                                        // from udp, it is not guaranteed to be aligned and needs to be
-                                        // checked.
-                                        if relay.transport == Transport::Tcp && res.method.is_none() {
-                                            let pad = response_buffer.len() % 4;
-                                            if pad > 0 {
-                                                response_buffer.extend_from_slice(&[0u8; 8][..(4 - pad)]);
+                                    if let Some(relay_socket) = res.allocation {
+                                            let relay_service = service.clone();
+                                            let relay_switch = switch.clone();
+                                            let relay_id = id;
+                                            let relay_shutdown = session_shutdown.clone();
+                                            tokio::spawn(async move {
+                                                let mut shutdown = relay_shutdown;
+                                                let mut cleanup = tokio::time::interval(Duration::from_secs(1));
+                                                loop {
+                                                    let mut packet = Buffer::new();
+                                                    tokio::select! {
+                                                        changed = shutdown.changed() => {
+                                                            if changed.is_err() || *shutdown.borrow() {
+                                                                break;
+                                                            }
+                                                        }
+                                                        _ = cleanup.tick() => {
+                                                            if relay_service.get_session_manager().relay_socket(&relay_id).is_none() {
+                                                                break;
+                                                            }
+                                                        }
+                                                        received = relay_socket.recv_buf_from(packet.deref_mut()) => {
+                                                            let Ok((_size, peer)) = received else {
+                                                                break;
+                                                            };
+                                                            let Some(inbound) = relay_service.get_session_manager().relay_from_peer(&relay_id, peer) else {
+                                                                continue;
+                                                            };
+                                                            let mut outbound = Buffer::new();
+                                                            if let Some(channel) = inbound.channel {
+                                                                ChannelData::new(channel, &packet).encode(&mut outbound);
+                                                            } else {
+                                                                let mut message = MessageEncoder::new(DATA_INDICATION, &[0; 12], &mut outbound);
+                                                                message.append::<XorPeerAddress>(peer);
+                                                                message.append::<Data>(&packet);
+                                                                if message.flush(None).is_err() {
+                                                                    continue;
+                                                                }
+                                                            }
+                                                            relay_switch.send(&relay_id, outbound);
+                                                        }
+                                                    }
+                                                }
+                                            });
+                                        }
+
+                                        if let Some(RelayTarget::Peer { socket: relay_socket, peer }) = res.relay {
+                                            let _ = relay_socket.send_to(&response_buffer, peer).await;
+                                        } else {
+                                            if socket.write(&response_buffer).await.is_err() {
+                                                break;
+                                            }
+
+                                            reporter.send(
+                                                &id,
+                                                &[Stats::SendBytes(response_buffer.len()), Stats::SendPkts(1)],
+                                            );
+
+                                            if let Some(method) = res.method && method.is_error() {
+                                                reporter.send(&id, &[Stats::ErrorPkts(1)]);
                                             }
                                         }
-
-                                        switch.send(&relay, response_buffer);
-                                    } else {
-                                        if socket.write(&response_buffer).await.is_err() {
-                                            break;
-                                        }
-
-                                        reporter.send(
-                                            &id,
-                                            &[Stats::SendBytes(response_buffer.len()), Stats::SendPkts(1)],
-                                        );
-
-                                        if let Some(method) = res.method && method.is_error() {
-                                            reporter.send(&id, &[Stats::ErrorPkts(1)]);
-                                        }
-                                    }
                                 }
                             }
                             Some(bytes) = receiver.recv() => {

--- a/src/server/provider/mod.rs
+++ b/src/server/provider/mod.rs
@@ -4,13 +4,12 @@ pub mod udp;
 use std::{net::SocketAddr, task::Poll, time::Duration};
 
 use anyhow::Result;
-use tokio::time::interval;
+use tokio::{sync::watch, time::interval};
 
 use crate::{
-    Service,
     config::Ssl,
     server::{Switch, buffer::Buffer},
-    service::{Transport, session::Identifier},
+    service::{Service, ServiceHandler, Transport, session::Identifier},
     statistics::{Statistics, Stats},
 };
 
@@ -34,7 +33,10 @@ pub trait ProviderServer: Sized + Send {
     type Stream: ProviderStream;
 
     /// Bind the server to the specified address.
-    fn bind(options: &ServerOptions) -> impl Future<Output = Result<Self>> + Send;
+    fn bind(
+        options: &ServerOptions,
+        shutdown: watch::Receiver<bool>,
+    ) -> impl Future<Output = Result<Self>> + Send;
 
     /// Accept a new connection.
     fn accept(&mut self) -> impl Future<Output = Result<Poll<(Self::Stream, SocketAddr)>>> + Send;
@@ -43,18 +45,23 @@ pub trait ProviderServer: Sized + Send {
     fn local_addr(&self) -> Result<SocketAddr>;
 
     /// Start the server.
-    fn start(
+    fn start<T>(
         options: ServerOptions,
-        service: Service,
+        service: Service<T>,
         statistics: Statistics,
         switch: Switch,
-    ) -> impl Future<Output = Result<()>> + Send {
+        shutdown: watch::Receiver<bool>,
+    ) -> impl Future<Output = Result<()>> + Send
+    where
+        T: ServiceHandler + Clone,
+    {
         let transport = options.transport;
         let idle_timeout = options.idle_timeout as u64;
 
         async move {
-            let mut listener = Self::bind(&options).await?;
+            let mut listener = Self::bind(&options, shutdown.clone()).await?;
             let local_addr = listener.local_addr()?;
+            let mut shutdown = shutdown;
 
             log::info!(
                 "server listening: listen={}, external={}, local addr={local_addr}, transport={transport:?}",
@@ -62,7 +69,16 @@ pub trait ProviderServer: Sized + Send {
                 options.external,
             );
 
-            while let Ok(poll) = listener.accept().await {
+            loop {
+                let poll = tokio::select! {
+                    changed = shutdown.changed() => {
+                        if changed.is_err() || *shutdown.borrow() {
+                            break;
+                        }
+                        continue;
+                    }
+                    result = listener.accept() => result?,
+                };
                 let Poll::Ready((mut socket, address)) = poll else {
                     continue;
                 };
@@ -80,6 +96,7 @@ pub trait ProviderServer: Sized + Send {
 
                 let service = service.clone();
                 let switch = switch.clone();
+                let mut session_shutdown = shutdown.clone();
 
                 tokio::spawn(async move {
                     let mut interval = interval(Duration::from_secs(1));
@@ -89,6 +106,11 @@ pub trait ProviderServer: Sized + Send {
                         let mut response_buffer = Buffer::new();
 
                         tokio::select! {
+                            changed = session_shutdown.changed() => {
+                                if changed.is_err() || *session_shutdown.borrow() {
+                                    break;
+                                }
+                            }
                             Ok(buffer) = socket.read() => {
                                 read_delay = 0;
 

--- a/src/server/provider/mod.rs
+++ b/src/server/provider/mod.rs
@@ -102,7 +102,11 @@ pub trait ProviderServer: Sized + Send {
                         }
                         continue;
                     }
-                    result = listener.accept() => result?,
+                    result = listener.accept() => match result {
+                        Ok(poll) => poll,
+                        Err(_) if *shutdown.borrow() => break,
+                        Err(error) => return Err(error),
+                    },
                 };
                 let Poll::Ready((mut socket, address)) = poll else {
                     continue;

--- a/src/server/provider/tcp.rs
+++ b/src/server/provider/tcp.rs
@@ -118,7 +118,10 @@ pub struct TcpServer {
 impl ProviderServer for TcpServer {
     type Stream = MaybeSslStream;
 
-    async fn bind(options: &ServerOptions) -> Result<Self> {
+    async fn bind(
+        options: &ServerOptions,
+        _shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<Self> {
         #[cfg(feature = "ssl")]
         let acceptor = if let Some(ssl) = &options.ssl {
             Some(TlsAcceptor::from(Arc::new(

--- a/src/server/provider/udp.rs
+++ b/src/server/provider/udp.rs
@@ -57,7 +57,10 @@ pub struct UdpServer {
 impl ProviderServer for UdpServer {
     type Stream = UdpSession;
 
-    async fn bind(options: &ServerOptions) -> Result<Self> {
+    async fn bind(
+        options: &ServerOptions,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<Self> {
         let socket = Arc::new(UdpSocket::bind(options.listen).await?);
         let (socket_sender, socket_receiver) = unbounded_channel::<UdpSession>();
         let (close_signal_sender, mut close_signal_receiver) = unbounded_channel::<SocketAddr>();
@@ -72,6 +75,11 @@ impl ProviderServer for UdpServer {
                     let mut buffer = Buffer::new();
 
                     tokio::select! {
+                        changed = shutdown.changed() => {
+                            if changed.is_err() || *shutdown.borrow() {
+                                break;
+                            }
+                        }
                         ret = socket.recv_buf_from(buffer.deref_mut()) => {
                             let (size, addr) = match ret {
                                 Ok(it) => it,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,7 +3,10 @@ pub mod session;
 
 use std::{net::SocketAddr, sync::Arc};
 
-use crate::codec::{crypto::Password, message::attributes::PasswordAlgorithm};
+use crate::codec::{
+    crypto::Password,
+    message::{attributes::PasswordAlgorithm, methods::Method},
+};
 
 use self::{
     routing::Router,
@@ -39,6 +42,15 @@ pub trait ServiceHandler: Send + Sync + 'static {
         username: &str,
         algorithm: PasswordAlgorithm,
     ) -> impl Future<Output = Option<Password>> + Send;
+
+    /// Authorizes a long-term credential for a specific TURN request method.
+    ///
+    /// This runs before the password is cached for a session, allowing applications
+    /// to apply method-sensitive credential policies such as expiry only on Allocate.
+    #[allow(unused_variables)]
+    fn allows_auth(&self, id: &Identifier, username: &str, method: Method) -> bool {
+        true
+    }
 
     /// allocate request
     ///

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -52,6 +52,15 @@ pub trait ServiceHandler: Send + Sync + 'static {
         true
     }
 
+    /// Requests a 400 Bad Request response for an authenticated Allocate whose
+    /// username or message integrity validation fails.
+    ///
+    /// The default preserves RFC-style 401 challenges for existing users.
+    #[allow(unused_variables)]
+    fn allocate_auth_failure_is_bad_request(&self) -> bool {
+        false
+    }
+
     /// allocate request
     ///
     /// [rfc8489](https://tools.ietf.org/html/rfc8489)

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -89,6 +89,15 @@ pub trait ServiceHandler: Send + Sync + 'static {
     /// different channel, eliminating the possibility that the
     /// transaction would initially fail but succeed on a
     /// retransmission.
+    /// Returns whether a client may create a permission or channel binding for a peer.
+    ///
+    /// The default permits peers to preserve existing server behavior. Implementations
+    /// can reject a peer before any permission or channel binding state is installed.
+    #[allow(unused_variables)]
+    fn allows_peer(&self, client: &Identifier, peer: SocketAddr) -> bool {
+        true
+    }
+
     #[allow(unused_variables)]
     fn on_channel_bind(&self, id: &Identifier, username: &str, channel: u16) {}
 
@@ -120,7 +129,7 @@ pub trait ServiceHandler: Send + Sync + 'static {
     /// If the message is valid and the server is capable of carrying out the
     /// request, then the server installs or refreshes a permission for the
     /// IP address contained in each XOR-PEER-ADDRESS attribute as described
-    /// in [Section 9](https://tools.ietf.org/html/rfc8656#section-9).  
+    /// in [Section 9](https://tools.ietf.org/html/rfc8656#section-9).
     /// The port portion of each attribute is ignored and may be any arbitrary
     /// value.
     ///

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -1,5 +1,7 @@
 use std::{net::SocketAddr, sync::Arc};
 
+use tokio::net::UdpSocket;
+
 use bytes::BytesMut;
 use rand::seq::IteratorRandom;
 
@@ -127,8 +129,18 @@ where
 pub struct RouteResult {
     /// if the method is None, the response is a channel data response
     pub method: Option<Method>,
-    /// the relay target of the response
-    pub relay: Option<Identifier>,
+    /// The peer relay target for Send indications and ChannelData.
+    pub relay: Option<RelayTarget>,
+    /// The newly allocated UDP relay socket, if this response created one.
+    pub allocation: Option<Arc<UdpSocket>>,
+}
+
+#[derive(Debug)]
+pub enum RelayTarget {
+    Peer {
+        socket: Arc<UdpSocket>,
+        peer: SocketAddr,
+    },
 }
 
 pub(crate) struct RouterState<T>
@@ -234,6 +246,7 @@ where
     Some(RouteResult {
         method: Some(method),
         relay: None,
+        allocation: None,
     })
 }
 
@@ -275,6 +288,7 @@ where
     Some(RouteResult {
         method: Some(BINDING_RESPONSE),
         relay: None,
+        allocation: None,
     })
 }
 
@@ -378,6 +392,7 @@ where
     Some(RouteResult {
         method: Some(ALLOCATE_RESPONSE),
         relay: None,
+        allocation: req.state.manager.start_relay(&req.state.id),
     })
 }
 
@@ -426,7 +441,7 @@ where
         return reject(req, ErrorType::Unauthorized);
     };
 
-    let mut ports = Vec::with_capacity(15);
+    let mut peers = Vec::with_capacity(15);
     for it in req.payload.get_all::<XorPeerAddress>() {
         if !req.verify_ip(&it) {
             return reject(req, ErrorType::PeerAddressFamilyMismatch);
@@ -435,16 +450,18 @@ where
             return reject(req, ErrorType::Forbidden);
         }
 
-        ports.push(it.port());
+        peers.push(it);
     }
 
-    if !req.state.manager.create_permission(&req.state.id, &ports) {
+    if !req.state.manager.create_permission(&req.state.id, &peers) {
         return reject(req, ErrorType::Forbidden);
     }
 
-    req.state
-        .handler
-        .on_create_permission(&req.state.id, username, &ports);
+    req.state.handler.on_create_permission(
+        &req.state.id,
+        username,
+        &peers.iter().map(SocketAddr::port).collect::<Vec<_>>(),
+    );
 
     {
         MessageEncoder::extend(CREATE_PERMISSION_RESPONSE, req.payload, req.response_buffer)
@@ -455,6 +472,7 @@ where
     Some(RouteResult {
         method: Some(CREATE_PERMISSION_RESPONSE),
         relay: None,
+        allocation: None,
     })
 }
 
@@ -513,11 +531,7 @@ where
         return reject(req, ErrorType::Unauthorized);
     };
 
-    if !req
-        .state
-        .manager
-        .bind_channel(&req.state.id, peer.port(), number)
-    {
+    if !req.state.manager.bind_channel(&req.state.id, peer, number) {
         return reject(req, ErrorType::Forbidden);
     }
 
@@ -534,6 +548,7 @@ where
     Some(RouteResult {
         method: Some(CHANNEL_BIND_RESPONSE),
         relay: None,
+        allocation: None,
     })
 }
 
@@ -587,19 +602,13 @@ where
     let peer = req.payload.get::<XorPeerAddress>()?;
     let data = req.payload.get::<Data>()?;
 
-    let (local_port, relay) = req.state.manager.get_port_relay_address(&req.state.id, peer.port())?;
-
-    {
-        let mut message = MessageEncoder::extend(DATA_INDICATION, req.payload, req.response_buffer);
-
-        message.append::<XorPeerAddress>(SocketAddr::new(req.state.id.external.ip(), local_port));
-        message.append::<Data>(data);
-        message.flush(None).ok()?;
-    }
+    let socket = req.state.manager.relay_to_peer(&req.state.id, peer)?;
+    req.response_buffer.extend_from_slice(data);
 
     Some(RouteResult {
-        method: Some(DATA_INDICATION),
-        relay: Some(relay),
+        method: None,
+        relay: Some(RelayTarget::Peer { socket, peer }),
+        allocation: None,
     })
 }
 
@@ -670,6 +679,7 @@ where
     Some(RouteResult {
         method: Some(REFRESH_RESPONSE),
         relay: None,
+        allocation: None,
     })
 }
 
@@ -703,17 +713,16 @@ fn channel_data<T>(req: Request<'_, '_, T, ChannelData<'_>>) -> Option<RouteResu
 where
     T: ServiceHandler,
 {
-    let (relay_channel, relay) = req
+    let peer = req
         .state
         .manager
-        .get_channel_relay_address(&req.state.id, req.payload.number())?;
-
-    {
-        ChannelData::new(relay_channel, req.payload.bytes()).encode(req.response_buffer);
-    }
+        .channel_peer(&req.state.id, req.payload.number())?;
+    let socket = req.state.manager.relay_to_peer(&req.state.id, peer)?;
+    req.response_buffer.extend_from_slice(req.payload.bytes());
 
     Some(RouteResult {
-        relay: Some(relay),
+        relay: Some(RelayTarget::Peer { socket, peer }),
         method: None,
+        allocation: None,
     })
 }

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -38,19 +38,13 @@ impl<'a, 'b, T> Request<'a, 'b, T, Message<'a>>
 where
     T: ServiceHandler,
 {
-    // Verify the IP address specified by the client in the request, such as the
-    // peer address used when creating permissions and binding channels. Currently,
-    // only peer addresses that are local addresses of the TURN server are allowed;
-    // arbitrary addresses are not permitted.
-    //
-    // Allowing arbitrary addresses would pose security risks, such as enabling
-    // the TURN server to forward data to any target.
+    // RFC 8656 permits arbitrary peer addresses, but requires the peer address
+    // family to match that of the relayed address. Applications enforce their
+    // own peer authorization through `ServiceHandler::allows_peer` before any
+    // permission or channel state is installed.
     #[inline(always)]
     fn verify_ip(&self, address: &SocketAddr) -> bool {
-        self.state
-            .interfaces
-            .iter()
-            .any(|item| item.external.ip() == address.ip())
+        self.state.id.external.ip().family() == address.ip().family()
     }
 
     // The key for the HMAC depends on whether long-term or short-term

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -350,8 +350,9 @@ where
         ip
     };
 
+    let has_username = req.payload.get::<UserName>().is_some();
     let Some((username, password)) = req.verify().await else {
-        let error = if req.state.handler.allocate_auth_failure_is_bad_request() {
+        let error = if has_username && req.state.handler.allocate_auth_failure_is_bad_request() {
             ErrorType::BadRequest
         } else {
             ErrorType::Unauthorized

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -8,6 +8,9 @@ use super::{
     session::{DEFAULT_SESSION_LIFETIME, Identifier, SessionManager},
 };
 
+#[cfg(test)]
+mod tests;
+
 use crate::{
     codec::{
         DecodeResult, Decoder,
@@ -396,7 +399,7 @@ where
 /// If the message is valid and the server is capable of carrying out the
 /// request, then the server installs or refreshes a permission for the
 /// IP address contained in each XOR-PEER-ADDRESS attribute as described
-/// in [Section 9](https://tools.ietf.org/html/rfc8656#section-9).  
+/// in [Section 9](https://tools.ietf.org/html/rfc8656#section-9).
 /// The port portion of each attribute is ignored and may be any arbitrary
 /// value.
 ///
@@ -419,6 +422,9 @@ where
     for it in req.payload.get_all::<XorPeerAddress>() {
         if !req.verify_ip(&it) {
             return reject(req, ErrorType::PeerAddressFamilyMismatch);
+        }
+        if !req.state.handler.allows_peer(&req.state.id, it) {
+            return reject(req, ErrorType::Forbidden);
         }
 
         ports.push(it.port());
@@ -482,6 +488,9 @@ where
 
     if !req.verify_ip(&peer) {
         return reject(req, ErrorType::PeerAddressFamilyMismatch);
+    }
+    if !req.state.handler.allows_peer(&req.state.id, peer) {
+        return reject(req, ErrorType::Forbidden);
     }
 
     let Some(number) = req.payload.get::<ChannelNumber>() else {

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -351,7 +351,12 @@ where
     };
 
     let Some((username, password)) = req.verify().await else {
-        return reject(req, ErrorType::Unauthorized);
+        let error = if req.state.handler.allocate_auth_failure_is_bad_request() {
+            ErrorType::BadRequest
+        } else {
+            ErrorType::Unauthorized
+        };
+        return reject(req, error);
     };
 
     let lifetime = req.payload.get::<Lifetime>();

--- a/src/service/routing.rs
+++ b/src/service/routing.rs
@@ -106,6 +106,14 @@ where
             .get::<PasswordAlgorithm>()
             .unwrap_or(PasswordAlgorithm::Md5);
 
+        if !self
+            .state
+            .handler
+            .allows_auth(&self.state.id, username, self.payload.method())
+        {
+            return None;
+        }
+
         let password = self
             .state
             .manager

--- a/src/service/routing/tests.rs
+++ b/src/service/routing/tests.rs
@@ -1,0 +1,160 @@
+use std::net::SocketAddr;
+
+use bytes::BytesMut;
+
+use super::super::{InterfaceAddr, Service, ServiceHandler, ServiceOptions, Transport};
+use crate::{
+    codec::{
+        Attributes,
+        crypto::{Password, generate_password},
+        message::{
+            MessageEncoder,
+            attributes::{ChannelNumber, PasswordAlgorithm, UserName, XorPeerAddress},
+            methods::{CHANNEL_BIND_REQUEST, CREATE_PERMISSION_REQUEST},
+        },
+    },
+    service::session::{Identifier, ports::PortRange},
+};
+
+const REALM: &str = "test-realm";
+const USERNAME: &str = "test-user";
+const PASSWORD: &str = "test-password";
+
+#[derive(Clone)]
+struct DenyPeerHandler;
+
+impl ServiceHandler for DenyPeerHandler {
+    async fn get_password(
+        &self,
+        _id: &Identifier,
+        username: &str,
+        algorithm: PasswordAlgorithm,
+    ) -> Option<Password> {
+        (username == USERNAME).then(|| generate_password(username, PASSWORD, REALM, algorithm))
+    }
+
+    fn allows_peer(&self, _client: &Identifier, _peer: SocketAddr) -> bool {
+        false
+    }
+}
+
+fn identifier(source: &str) -> Identifier {
+    Identifier {
+        source: source.parse().expect("test source address should parse"),
+        external: "127.0.0.1:3478"
+            .parse()
+            .expect("test external address should parse"),
+        interface: "127.0.0.1:3478"
+            .parse()
+            .expect("test interface address should parse"),
+        transport: Transport::Udp,
+    }
+}
+
+fn service() -> Service<DenyPeerHandler> {
+    let client = identifier("127.0.0.1:50000");
+    Service::new(ServiceOptions {
+        port_range: PortRange::try_from(40000..40100).expect("test port range should be valid"),
+        realm: REALM.to_string(),
+        interfaces: vec![InterfaceAddr {
+            addr: client.interface,
+            external: client.external,
+            transport: Transport::Udp,
+        }],
+        handler: DenyPeerHandler,
+    })
+}
+
+async fn authenticate_and_allocate(
+    service: &Service<DenyPeerHandler>,
+    client: Identifier,
+    peer: Identifier,
+) -> u16 {
+    service
+        .get_session_manager()
+        .get_password(&client, USERNAME, PasswordAlgorithm::Md5)
+        .await
+        .expect("client should authenticate");
+    service
+        .get_session_manager()
+        .get_password(&peer, USERNAME, PasswordAlgorithm::Md5)
+        .await
+        .expect("peer should authenticate");
+    service
+        .get_session_manager()
+        .allocate(&client, None)
+        .expect("client should allocate a relay port");
+    service
+        .get_session_manager()
+        .allocate(&peer, None)
+        .expect("peer should allocate a relay port")
+}
+
+#[tokio::test]
+async fn denied_peer_permission_returns_forbidden() {
+    let client = identifier("127.0.0.1:50000");
+    let peer = identifier("127.0.0.1:50001");
+    let service = service();
+    let password = generate_password(USERNAME, PASSWORD, REALM, PasswordAlgorithm::Md5);
+    let peer_port = authenticate_and_allocate(&service, client, peer).await;
+
+    let mut request = BytesMut::new();
+    let mut encoder = MessageEncoder::new(CREATE_PERMISSION_REQUEST, &[7; 12], &mut request);
+    encoder.append::<UserName>(USERNAME);
+    encoder.append::<XorPeerAddress>(SocketAddr::new(peer.external.ip(), peer_port));
+    encoder
+        .flush(Some(&password))
+        .expect("request should encode");
+
+    let mut router = service.make_router(client);
+    let mut response = BytesMut::new();
+    let result = router
+        .route(&request, &mut response)
+        .await
+        .expect("request should route")
+        .expect("request should receive a response");
+
+    assert_eq!(
+        result.method,
+        Some(crate::codec::message::methods::CREATE_PERMISSION_ERROR)
+    );
+
+    let mut attributes = Attributes::default();
+    let response = crate::codec::message::Message::decode(&response, &mut attributes)
+        .expect("response should decode");
+    assert_eq!(
+        response.method(),
+        crate::codec::message::methods::CREATE_PERMISSION_ERROR
+    );
+}
+
+#[tokio::test]
+async fn denied_peer_channel_bind_returns_forbidden() {
+    let client = identifier("127.0.0.1:50000");
+    let peer = identifier("127.0.0.1:50001");
+    let service = service();
+    let password = generate_password(USERNAME, PASSWORD, REALM, PasswordAlgorithm::Md5);
+    let peer_port = authenticate_and_allocate(&service, client, peer).await;
+
+    let mut request = BytesMut::new();
+    let mut encoder = MessageEncoder::new(CHANNEL_BIND_REQUEST, &[8; 12], &mut request);
+    encoder.append::<UserName>(USERNAME);
+    encoder.append::<XorPeerAddress>(SocketAddr::new(peer.external.ip(), peer_port));
+    encoder.append::<ChannelNumber>(0x4000);
+    encoder
+        .flush(Some(&password))
+        .expect("request should encode");
+
+    let mut router = service.make_router(client);
+    let mut response = BytesMut::new();
+    let result = router
+        .route(&request, &mut response)
+        .await
+        .expect("request should route")
+        .expect("request should receive a response");
+
+    assert_eq!(
+        result.method,
+        Some(crate::codec::message::methods::CHANNEL_BIND_ERROR)
+    );
+}

--- a/src/service/routing/tests.rs
+++ b/src/service/routing/tests.rs
@@ -126,6 +126,12 @@ async fn denied_peer_permission_returns_forbidden() {
         response.method(),
         crate::codec::message::methods::CREATE_PERMISSION_ERROR
     );
+    assert!(
+        service
+            .get_session_manager()
+            .relay_to_peer(&client, SocketAddr::new(peer.external.ip(), peer_port))
+            .is_none()
+    );
 }
 
 #[tokio::test]
@@ -156,5 +162,11 @@ async fn denied_peer_channel_bind_returns_forbidden() {
     assert_eq!(
         result.method,
         Some(crate::codec::message::methods::CHANNEL_BIND_ERROR)
+    );
+    assert!(
+        service
+            .get_session_manager()
+            .relay_to_peer(&client, SocketAddr::new(peer.external.ip(), peer_port))
+            .is_none()
     );
 }

--- a/src/service/session/mod.rs
+++ b/src/service/session/mod.rs
@@ -1,4 +1,4 @@
-﻿pub mod ports;
+pub mod ports;
 
 use super::{
     ServiceHandler, Transport,
@@ -9,12 +9,10 @@ use crate::codec::{crypto::Password, message::attributes::PasswordAlgorithm};
 
 use std::{
     hash::Hash,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     ops::{Deref, DerefMut},
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
     thread::{self, sleep},
     time::Duration,
 };
@@ -22,6 +20,7 @@ use std::{
 use ahash::{HashMap, HashMapExt};
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use rand::{Rng, distr::Alphanumeric};
+use tokio::net::UdpSocket;
 
 /// The identifier of the session.
 ///
@@ -138,12 +137,10 @@ pub enum Session {
         ///
         /// SessionManager are all bound to only one port and one channel.
         allocated_port: Option<u16>,
-        // Stores the address to which the session should be forwarded when it sends indication to a
-        // port. This is written when permissions are created to allow a certain address to be
-        // forwarded to the current session.
-        port_relay_table: HashMap</* port */ u16, Identifier>,
-        // Indicates to which session the data sent by a session to a channel should be forwarded.
-        channel_relay_table: HashMap</* channel */ u16, Identifier>,
+        relay_socket: Option<Arc<UdpSocket>>,
+        relay_started: bool,
+        permissions: HashMap<IpAddr, u64>,
+        channels: HashMap<u16, ChannelBinding>,
         expires: u64,
     },
 }
@@ -172,12 +169,20 @@ pub struct SessionManagerOptions<T> {
     pub handler: T,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ChannelBinding {
+    peer: SocketAddr,
+    expires: u64,
+}
+
+/// RFC 8656 permissions are refreshed for five minutes.
+const DEFAULT_PERMISSION_LIFETIME: u64 = 300;
+/// RFC 8656 channel bindings are refreshed for ten minutes.
+const DEFAULT_CHANNEL_LIFETIME: u64 = 600;
+
 pub struct SessionManager<T> {
     sessions: RwLock<Table<Identifier, Session>>,
     port_allocator: Mutex<PortAllocator>,
-    // Records the sessions corresponding to each assigned port, which will be needed when looking
-    // up sessions assigned to this port based on the port number.
-    port_mapping_table: RwLock<Table</* port */ u16, Identifier>>,
     timer: Timer,
     handler: T,
 }
@@ -189,7 +194,6 @@ where
     pub fn new(options: SessionManagerOptions<T>) -> Arc<Self> {
         let this = Arc::new(Self {
             port_allocator: Mutex::new(PortAllocator::new(options.port_range)),
-            port_mapping_table: RwLock::new(Table::default()),
             sessions: RwLock::new(Table::default()),
             timer: Timer::default(),
             handler: options.handler,
@@ -237,7 +241,6 @@ where
     fn remove_session(&self, identifiers: &[Identifier]) {
         let mut sessions = self.sessions.write();
         let mut port_allocator = self.port_allocator.lock();
-        let mut port_mapping_table = self.port_mapping_table.write();
 
         identifiers.iter().for_each(|k| {
             if let Some(Session::Authenticated {
@@ -249,7 +252,6 @@ where
                 // Removes the session-bound port from the port binding table and
                 // releases the port back into the allocation pool.
                 if let Some(port) = allocated_port {
-                    port_mapping_table.remove(&port);
                     port_allocator.deallocate(port);
                 }
 
@@ -461,8 +463,10 @@ where
             lock.insert(
                 *identifier,
                 Session::Authenticated {
-                    port_relay_table: HashMap::with_capacity(10),
-                    channel_relay_table: HashMap::with_capacity(10),
+                    relay_socket: None,
+                    relay_started: false,
+                    permissions: HashMap::with_capacity(10),
+                    channels: HashMap::with_capacity(10),
                     expires: self.timer.get() + DEFAULT_SESSION_LIFETIME,
                     username: username.to_string(),
                     allocated_port: None,
@@ -552,459 +556,202 @@ where
     /// assert_eq!(sessions.allocate(&identifier, None), Some(port));
     /// ```
     pub fn allocate(&self, identifier: &Identifier, lifetime: Option<u32>) -> Option<u16> {
-        let mut lock = self.sessions.write();
-
         if let Some(Session::Authenticated {
+            allocated_port: Some(port),
+            ..
+        }) = self.sessions.read().get(identifier)
+        {
+            return Some(*port);
+        }
+
+        let (port, relay_socket) = loop {
+            let port = self.port_allocator.lock().allocate(None)?;
+            let address = SocketAddr::new(identifier.interface.ip(), port);
+            let socket = match std::net::UdpSocket::bind(address) {
+                Ok(socket) => socket,
+                Err(_) => {
+                    self.port_allocator.lock().deallocate(port);
+                    continue;
+                }
+            };
+            if socket.set_nonblocking(true).is_err() {
+                self.port_allocator.lock().deallocate(port);
+                continue;
+            }
+            match UdpSocket::from_std(socket) {
+                Ok(socket) => break (port, Arc::new(socket)),
+                Err(_) => self.port_allocator.lock().deallocate(port),
+            }
+        };
+
+        let mut sessions = self.sessions.write();
+        let Some(Session::Authenticated {
             allocated_port,
+            relay_socket: session_socket,
             expires,
             ..
-        }) = lock.get_mut(identifier)
-        {
-            // If the port has already been allocated, re-allocation is not allowed.
-            if let Some(port) = allocated_port {
-                return Some(*port);
-            }
+        }) = sessions.get_mut(identifier)
+        else {
+            self.port_allocator.lock().deallocate(port);
+            return None;
+        };
 
-            // Records the port assigned to the current session and resets the alive time.
-            let port = self.port_allocator.lock().allocate(None)?;
-            *allocated_port = Some(port);
-            *expires =
-                self.timer.get() + (lifetime.unwrap_or(DEFAULT_SESSION_LIFETIME as u32) as u64);
-
-            // Write the allocation port binding table.
-            self.port_mapping_table.write().insert(port, *identifier);
-            Some(port)
-        } else {
-            None
+        if let Some(existing_port) = allocated_port {
+            self.port_allocator.lock().deallocate(port);
+            return Some(*existing_port);
         }
+
+        *allocated_port = Some(port);
+        *session_socket = Some(relay_socket);
+        *expires = self.timer.get() + lifetime.unwrap_or(DEFAULT_SESSION_LIFETIME as u32) as u64;
+        Some(port)
     }
 
-    /// Create permission for session.
-    ///
-    /// # Test
-    ///
-    /// ```
-    /// use turn_server::service::session::*;
-    /// use turn_server::service::*;
-    /// use turn_server::codec::message::attributes::PasswordAlgorithm;
-    /// use turn_server::codec::crypto::Password;
-    /// use pollster::FutureExt;
-    ///
-    /// #[derive(Clone)]
-    /// struct ServiceHandlerTest;
-    ///
-    /// impl ServiceHandler for ServiceHandlerTest {
-    ///     async fn get_password(&self, id: &Identifier, username: &str, algorithm: PasswordAlgorithm) -> Option<Password> {
-    ///         if username == "test" {
-    ///             Some(turn_server::codec::crypto::generate_password(username, "test", "test", algorithm))
-    ///         } else {
-    ///             None
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// let identifier = Identifier {
-    ///     source: "127.0.0.1:8080".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let peer_identifier = Identifier {
-    ///     source: "127.0.0.1:8081".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let digest = Password::Md5([
-    ///     174, 238, 187, 253, 117, 209, 73, 157, 36, 56, 143, 91, 155, 16, 224,
-    ///     239,
-    /// ]);
-    ///
-    /// let sessions = SessionManager::new(SessionManagerOptions {
-    ///     port_range: (49152..65535).into(),
-    ///     handler: ServiceHandlerTest,
-    /// });
-    ///
-    /// sessions.get_password(&identifier, "test", PasswordAlgorithm::Md5).block_on();
-    /// sessions.get_password(&peer_identifier, "test", PasswordAlgorithm::Md5).block_on();
-    ///
-    /// let port = sessions.allocate(&identifier, None).unwrap();
-    /// let peer_port = sessions.allocate(&peer_identifier, None).unwrap();
-    ///
-    /// assert!(!sessions.create_permission(&identifier, &[port]));
-    /// assert!(sessions.create_permission(&identifier, &[peer_port]));
-    ///
-    /// assert!(!sessions.create_permission(&peer_identifier, &[peer_port]));
-    /// assert!(sessions.create_permission(&peer_identifier, &[port]));
-    /// ```
-    pub fn create_permission(&self, identifier: &Identifier, ports: &[u16]) -> bool {
-        // Finds information about the current session.
-        if let Some(Session::Authenticated {
+    /// Installs or refreshes RFC 8656 IP-scoped permissions for an allocation.
+    pub fn create_permission(&self, identifier: &Identifier, peers: &[SocketAddr]) -> bool {
+        let now = self.timer.get();
+        let mut sessions = self.sessions.write();
+        let Some(Session::Authenticated {
             allocated_port,
-            port_relay_table,
+            permissions,
             ..
-        }) = self.sessions.write().get_mut(identifier)
-        {
-            // The port number assigned to the current session.
-            let Some(local_port) = *allocated_port else {
-                return false;
-            };
+        }) = sessions.get_mut(identifier)
+        else {
+            return false;
+        };
 
-            // You cannot create permissions for yourself.
-            if ports.contains(&local_port) {
-                return false;
-            }
-
-            for port in ports {
-                if let Some(peer) = self.port_mapping_table.read().get(port) {
-                    // Check if the current port is already occupied by another client.
-                    if let Some(relay) = port_relay_table.get(&port)
-                        && relay != peer
-                    {
-                        return false;
-                    }
-
-                    port_relay_table.insert(*port, *peer);
-                } else {
-                    return false;
-                }
-            }
-
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Binding a channel to the session.
-    ///
-    /// # Test
-    ///
-    /// ```
-    /// use turn_server::service::session::*;
-    /// use turn_server::service::*;
-    /// use turn_server::codec::message::attributes::PasswordAlgorithm;
-    /// use turn_server::codec::crypto::Password;
-    /// use pollster::FutureExt;
-    ///
-    /// #[derive(Clone)]
-    /// struct ServiceHandlerTest;
-    ///
-    /// impl ServiceHandler for ServiceHandlerTest {
-    ///     async fn get_password(&self, id: &Identifier, username: &str, algorithm: PasswordAlgorithm) -> Option<Password> {
-    ///         if username == "test" {
-    ///             Some(turn_server::codec::crypto::generate_password(username, "test", "test", algorithm))
-    ///         } else {
-    ///             None
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// let identifier = Identifier {
-    ///     source: "127.0.0.1:8080".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let peer_identifier = Identifier {
-    ///     source: "127.0.0.1:8081".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let digest = Password::Md5([
-    ///     174, 238, 187, 253, 117, 209, 73, 157, 36, 56, 143, 91, 155, 16, 224,
-    ///     239,
-    /// ]);
-    ///
-    /// let sessions = SessionManager::new(SessionManagerOptions {
-    ///     port_range: (49152..65535).into(),
-    ///     handler: ServiceHandlerTest,
-    /// });
-    ///
-    /// sessions.get_password(&identifier, "test", PasswordAlgorithm::Md5).block_on();
-    /// sessions.get_password(&peer_identifier, "test", PasswordAlgorithm::Md5).block_on();
-    ///
-    /// let port = sessions.allocate(&identifier, None).unwrap();
-    /// let peer_port = sessions.allocate(&peer_identifier, None).unwrap();
-    /// {
-    ///     assert_eq!(
-    ///         match sessions.get_session(&identifier).get_ref().unwrap() {
-    ///             Session::Authenticated { channel_relay_table, .. } => channel_relay_table.len(),
-    ///             _ => panic!("Expected authenticated session"),
-    ///         },
-    ///         0
-    ///     );
-    /// }
-    ///
-    /// {
-    ///     assert_eq!(
-    ///         match sessions.get_session(&peer_identifier).get_ref().unwrap() {
-    ///             Session::Authenticated { channel_relay_table, .. } => channel_relay_table.len(),
-    ///             _ => panic!("Expected authenticated session"),
-    ///         },
-    ///         0
-    ///     );
-    /// }
-    ///
-    /// assert!(sessions.bind_channel(&identifier, peer_port, 0x4000));
-    /// assert!(sessions.bind_channel(&peer_identifier, port, 0x4000));
-    ///
-    /// {
-    ///     assert!(
-    ///         match sessions.get_session(&identifier).get_ref().unwrap() {
-    ///             Session::Authenticated { channel_relay_table, .. } => channel_relay_table.contains_key(&0x4000),
-    ///             _ => panic!("Expected authenticated session"),
-    ///         }
-    ///     );
-    /// }
-    ///
-    /// {
-    ///     assert!(
-    ///         match sessions.get_session(&peer_identifier).get_ref().unwrap() {
-    ///             Session::Authenticated { channel_relay_table, .. } => channel_relay_table.contains_key(&0x4000),
-    ///             _ => panic!("Expected authenticated session"),
-    ///         }
-    ///     );
-    /// }
-    /// ```
-    pub fn bind_channel(&self, identifier: &Identifier, port: u16, channel: u16) -> bool {
-        // Records the channel used for the current session.
-        {
-            if let Some(Session::Authenticated {
-                channel_relay_table,
-                ..
-            }) = self.sessions.write().get_mut(identifier)
-            {
-                // Finds the address of the bound opposing port.
-                if let Some(peer) = self.port_mapping_table.read().get(&port) {
-                    // Check if the current channel is already occupied by another client.
-                    if let Some(relay) = channel_relay_table.get(&channel)
-                        && relay != peer
-                    {
-                        return false;
-                    }
-
-                    // Create channel forwarding mapping relationships for peers.
-                    channel_relay_table.insert(channel, *peer);
-                } else {
-                    return false;
-                };
-            } else {
-                return false;
-            };
-        }
-
-        // Binding ports also creates permissions.
-        if !self.create_permission(identifier, &[port]) {
+        if allocated_port.is_none() {
             return false;
         }
 
+        for peer in peers {
+            permissions.insert(peer.ip(), now + DEFAULT_PERMISSION_LIFETIME);
+        }
         true
     }
 
-    /// Gets the peer of the current session bound channel.
-    ///
-    /// # Test
-    ///
-    /// ```
-    /// use turn_server::service::session::*;
-    /// use turn_server::service::*;
-    /// use turn_server::codec::message::attributes::PasswordAlgorithm;
-    /// use turn_server::codec::crypto::Password;
-    /// use pollster::FutureExt;
-    ///
-    /// #[derive(Clone)]
-    /// struct ServiceHandlerTest;
-    ///
-    /// impl ServiceHandler for ServiceHandlerTest {
-    ///     async fn get_password(&self, id: &Identifier, username: &str, algorithm: PasswordAlgorithm) -> Option<Password> {
-    ///         if username == "test" {
-    ///             Some(turn_server::codec::crypto::generate_password(username, "test", "test", algorithm))
-    ///         } else {
-    ///             None
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// let endpoint = "127.0.0.1:3478".parse().unwrap();
-    /// let identifier = Identifier {
-    ///     source: "127.0.0.1:8080".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let peer_identifier = Identifier {
-    ///     source: "127.0.0.1:8081".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let digest = Password::Md5([
-    ///     174, 238, 187, 253, 117, 209, 73, 157, 36, 56, 143, 91, 155, 16, 224,
-    ///     239,
-    /// ]);
-    ///
-    /// let sessions = SessionManager::new(SessionManagerOptions {
-    ///     port_range: (49152..65535).into(),
-    ///     handler: ServiceHandlerTest,
-    /// });
-    ///
-    /// sessions.get_password(&identifier, "test", PasswordAlgorithm::Md5).block_on();
-    /// sessions.get_password(&peer_identifier, "test", PasswordAlgorithm::Md5).block_on();
-    ///
-    /// let port = sessions.allocate(&identifier, None).unwrap();
-    /// let peer_port = sessions.allocate(&peer_identifier, None).unwrap();
-    ///
-    /// assert!(sessions.bind_channel(&identifier, peer_port, 0x4000));
-    /// assert!(sessions.bind_channel(&peer_identifier, port, 0x4000));
-    /// assert_eq!(
-    ///     sessions
-    ///         .get_channel_relay_address(&identifier, 0x4000)
-    ///         .unwrap()
-    ///         .1
-    ///         .interface,
-    ///     endpoint
-    /// );
-    ///
-    /// assert_eq!(
-    ///     sessions
-    ///         .get_channel_relay_address(&peer_identifier, 0x4000)
-    ///         .unwrap()
-    ///         .1
-    ///         .interface,
-    ///     endpoint
-    /// );
-    /// ```
-    pub fn get_channel_relay_address(
-        &self,
-        identifier: &Identifier,
-        channel: u16,
-    ) -> Option<(/* peer channel */ u16, Identifier)> {
-        let session = self.sessions.read();
-
-        if let Session::Authenticated {
-            channel_relay_table,
+    /// Binds a channel to a peer socket and refreshes its IP permission.
+    pub fn bind_channel(&self, identifier: &Identifier, peer: SocketAddr, channel: u16) -> bool {
+        let now = self.timer.get();
+        let mut sessions = self.sessions.write();
+        let Some(Session::Authenticated {
+            allocated_port,
+            permissions,
+            channels,
             ..
-        } = session.get(identifier)?
+        }) = sessions.get_mut(identifier)
+        else {
+            return false;
+        };
+
+        if allocated_port.is_none()
+            || channels
+                .get(&channel)
+                .is_some_and(|binding| binding.peer != peer)
+            || channels
+                .iter()
+                .any(|(number, binding)| *number != channel && binding.peer == peer)
         {
-            let peer = channel_relay_table.get(&channel)?;
-
-            if let Session::Authenticated {
-                channel_relay_table,
-                ..
-            } = session.get(peer)?
-            {
-                // Find the channel bound to the current client.
-                let (peer_channel, _) =
-                    channel_relay_table.iter().find(|(_, v)| *v == identifier)?;
-
-                Some((*peer_channel, *peer))
-            } else {
-                None
-            }
-        } else {
-            None
+            return false;
         }
+
+        permissions.insert(peer.ip(), now + DEFAULT_PERMISSION_LIFETIME);
+        channels.insert(
+            channel,
+            ChannelBinding {
+                peer,
+                expires: now + DEFAULT_CHANNEL_LIFETIME,
+            },
+        );
+        true
     }
 
-    /// Get the address of the port binding.
-    ///
-    /// # Test
-    ///
-    /// ```
-    /// use turn_server::service::session::*;
-    /// use turn_server::service::*;
-    /// use turn_server::codec::message::attributes::PasswordAlgorithm;
-    /// use turn_server::codec::crypto::Password;
-    /// use pollster::FutureExt;
-    ///
-    /// #[derive(Clone)]
-    /// struct ServiceHandlerTest;
-    ///
-    /// impl ServiceHandler for ServiceHandlerTest {
-    ///     async fn get_password(&self, id: &Identifier, username: &str, algorithm: PasswordAlgorithm) -> Option<Password> {
-    ///         if username == "test" {
-    ///             Some(turn_server::codec::crypto::generate_password(username, "test", "test", algorithm))
-    ///         } else {
-    ///             None
-    ///         }
-    ///     }
-    /// }
-    ///
-    /// let endpoint = "127.0.0.1:3478".parse().unwrap();
-    /// let identifier = Identifier {
-    ///     source: "127.0.0.1:8080".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let peer_identifier = Identifier {
-    ///     source: "127.0.0.1:8081".parse().unwrap(),
-    ///     external: "127.0.0.1:3478".parse().unwrap(),
-    ///     interface: "127.0.0.1:3478".parse().unwrap(),
-    ///     transport: Transport::Udp,
-    /// };
-    ///
-    /// let digest = Password::Md5([
-    ///     174, 238, 187, 253, 117, 209, 73, 157, 36, 56, 143, 91, 155, 16, 224,
-    ///     239,
-    /// ]);
-    ///
-    /// let sessions = SessionManager::new(SessionManagerOptions {
-    ///     port_range: (49152..65535).into(),
-    ///     handler: ServiceHandlerTest,
-    /// });
-    ///
-    /// sessions.get_password(&identifier, "test", PasswordAlgorithm::Md5).block_on();
-    /// sessions.get_password(&peer_identifier, "test", PasswordAlgorithm::Md5).block_on();
-    ///
-    /// let port = sessions.allocate(&identifier, None).unwrap();
-    /// let peer_port = sessions.allocate(&peer_identifier, None).unwrap();
-    ///
-    /// assert!(sessions.create_permission(&identifier, &[peer_port]));
-    /// assert!(sessions.create_permission(&peer_identifier, &[port]));
-    ///
-    /// assert_eq!(
-    ///     sessions
-    ///         .get_port_relay_address(&identifier, peer_port)
-    ///         .unwrap()
-    ///         .1
-    ///         .interface,
-    ///     endpoint
-    /// );
-    ///
-    /// assert_eq!(
-    ///     sessions
-    ///         .get_port_relay_address(&peer_identifier, port)
-    ///         .unwrap()
-    ///         .1
-    ///         .interface,
-    ///     endpoint
-    /// );
-    /// ```
-    pub fn get_port_relay_address(
+    /// Returns the peer socket bound to a channel while its binding is live.
+    pub(crate) fn channel_peer(&self, identifier: &Identifier, channel: u16) -> Option<SocketAddr> {
+        let now = self.timer.get();
+        let session = self.sessions.read();
+        let Session::Authenticated { channels, .. } = session.get(identifier)? else {
+            return None;
+        };
+        let binding = channels.get(&channel)?;
+        (binding.expires > now).then_some(binding.peer)
+    }
+
+    /// Returns the allocation relay socket when a live permission authorizes a peer.
+    pub(crate) fn relay_to_peer(
         &self,
         identifier: &Identifier,
-        port: u16,
-    ) -> Option<(/* local port */ u16, Identifier)> {
-        if let Session::Authenticated {
-            port_relay_table,
-            allocated_port,
+        peer: SocketAddr,
+    ) -> Option<Arc<UdpSocket>> {
+        let now = self.timer.get();
+        let session = self.sessions.read();
+        let Session::Authenticated {
+            relay_socket,
+            permissions,
             ..
-        } = self.sessions.read().get(identifier)?
-        {
-            Some(((*allocated_port)?, port_relay_table.get(&port).copied()?))
-        } else {
-            None
+        } = session.get(identifier)?
+        else {
+            return None;
+        };
+
+        (permissions.get(&peer.ip()).copied()? > now)
+            .then(|| relay_socket.clone())
+            .flatten()
+    }
+
+    /// Looks up how an inbound relay datagram should be delivered to its client.
+    pub(crate) fn relay_from_peer(
+        &self,
+        identifier: &Identifier,
+        peer: SocketAddr,
+    ) -> Option<RelayInbound> {
+        let now = self.timer.get();
+        let session = self.sessions.read();
+        let Session::Authenticated {
+            permissions,
+            channels,
+            ..
+        } = session.get(identifier)?
+        else {
+            return None;
+        };
+
+        if permissions.get(&peer.ip()).copied()? <= now {
+            return None;
         }
+
+        let channel = channels.iter().find_map(|(number, binding)| {
+            (binding.peer == peer && binding.expires > now).then_some(*number)
+        });
+        Some(RelayInbound { channel })
+    }
+
+    /// Reports whether the allocation still owns a relay socket.
+    pub(crate) fn relay_socket(&self, identifier: &Identifier) -> Option<Arc<UdpSocket>> {
+        let session = self.sessions.read();
+        let Session::Authenticated { relay_socket, .. } = session.get(identifier)? else {
+            return None;
+        };
+        relay_socket.clone()
+    }
+
+    /// Marks a relay socket as owned by a provider worker and returns it once.
+    pub(crate) fn start_relay(&self, identifier: &Identifier) -> Option<Arc<UdpSocket>> {
+        let mut sessions = self.sessions.write();
+        let Session::Authenticated {
+            relay_socket,
+            relay_started,
+            ..
+        } = sessions.get_mut(identifier)?
+        else {
+            return None;
+        };
+        if *relay_started {
+            return None;
+        }
+        let socket = relay_socket.clone()?;
+        *relay_started = true;
+        Some(socket)
     }
 
     /// Refresh the session for identifier.
@@ -1093,6 +840,137 @@ where
         }
 
         true
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RelayInbound {
+    pub channel: Option<u16>,
+}
+
+#[cfg(test)]
+mod relay_state_tests {
+    use super::*;
+    use crate::service::Transport;
+    use tokio::time::{Duration, timeout};
+
+    #[derive(Clone)]
+    struct Handler;
+
+    impl ServiceHandler for Handler {
+        async fn get_password(
+            &self,
+            _id: &Identifier,
+            _username: &str,
+            _algorithm: PasswordAlgorithm,
+        ) -> Option<Password> {
+            Some(Password::Md5([0; 16]))
+        }
+    }
+
+    fn id(port: u16) -> Identifier {
+        Identifier {
+            source: SocketAddr::from(([127, 0, 0, 1], port)),
+            interface: SocketAddr::from(([127, 0, 0, 1], 3478)),
+            external: SocketAddr::from(([127, 0, 0, 1], 3478)),
+            transport: Transport::Udp,
+        }
+    }
+
+    #[tokio::test]
+    async fn arbitrary_peer_permission_is_ip_scoped() {
+        let manager = SessionManager::new(SessionManagerOptions {
+            port_range: (40000..40100).into(),
+            handler: Handler,
+        });
+        let client = id(50000);
+        manager
+            .get_password(&client, "user", PasswordAlgorithm::Md5)
+            .await;
+        manager
+            .allocate(&client, None)
+            .expect("allocation should succeed");
+        let peer = SocketAddr::from(([127, 0, 0, 1], 59999));
+
+        assert!(manager.create_permission(&client, &[peer]));
+        assert!(manager.relay_to_peer(&client, peer).is_some());
+        assert!(
+            manager
+                .relay_to_peer(&client, SocketAddr::from(([127, 0, 0, 1], 1)))
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn permitted_arbitrary_udp_peer_exchanges_datagrams_with_relay_socket() {
+        let manager = SessionManager::new(SessionManagerOptions {
+            port_range: (40200..40300).into(),
+            handler: Handler,
+        });
+        let client = id(50002);
+        manager
+            .get_password(&client, "user", PasswordAlgorithm::Md5)
+            .await;
+        manager
+            .allocate(&client, None)
+            .expect("allocation should succeed");
+
+        let peer = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("peer socket should bind");
+        let peer_address = peer.local_addr().expect("peer address should be available");
+        assert!(manager.create_permission(&client, &[peer_address]));
+
+        let relay = manager
+            .relay_to_peer(&client, peer_address)
+            .expect("permission should expose the relay socket");
+        relay
+            .send_to(b"request", peer_address)
+            .await
+            .expect("relay should send to arbitrary peer");
+
+        let mut received = [0; 32];
+        let (size, relay_address) = timeout(Duration::from_secs(1), peer.recv_from(&mut received))
+            .await
+            .expect("peer receive should not time out")
+            .expect("peer receive should succeed");
+        assert_eq!(&received[..size], b"request");
+        peer.send_to(b"response", relay_address)
+            .await
+            .expect("peer should send response to relay");
+
+        let (size, source) = timeout(Duration::from_secs(1), relay.recv_from(&mut received))
+            .await
+            .expect("relay receive should not time out")
+            .expect("relay receive should succeed");
+        assert_eq!(source, peer_address);
+        assert_eq!(&received[..size], b"response");
+    }
+
+    #[tokio::test]
+    async fn channel_binding_installs_permission_for_peer_socket() {
+        let manager = SessionManager::new(SessionManagerOptions {
+            port_range: (40100..40200).into(),
+            handler: Handler,
+        });
+        let client = id(50001);
+        manager
+            .get_password(&client, "user", PasswordAlgorithm::Md5)
+            .await;
+        manager
+            .allocate(&client, None)
+            .expect("allocation should succeed");
+        let peer = SocketAddr::from(([127, 0, 0, 1], 59998));
+
+        assert!(manager.bind_channel(&client, peer, 0x4000));
+        assert!(manager.relay_to_peer(&client, peer).is_some());
+        assert_eq!(
+            manager
+                .relay_from_peer(&client, peer)
+                .expect("peer should be permitted")
+                .channel,
+            Some(0x4000)
+        );
     }
 }
 

--- a/src/service/session/mod.rs
+++ b/src/service/session/mod.rs
@@ -175,6 +175,13 @@ pub struct ChannelBinding {
     expires: u64,
 }
 
+impl ChannelBinding {
+    /// Returns the full peer address associated with this binding.
+    pub fn peer(&self) -> SocketAddr {
+        self.peer
+    }
+}
+
 /// RFC 8656 permissions are refreshed for five minutes.
 const DEFAULT_PERMISSION_LIFETIME: u64 = 300;
 /// RFC 8656 channel bindings are refreshed for ten minutes.

--- a/src/service/session/mod.rs
+++ b/src/service/session/mod.rs
@@ -330,10 +330,11 @@ where
     ///     let lock = sessions.get_session(&identifier);
     ///     let session = lock.get_ref().unwrap();
     ///     match session {
-    ///         Session::Authenticated { username, allocated_port, channel_relay_table, .. } => {
+    ///         Session::Authenticated { username, allocated_port, permissions, channels, .. } => {
     ///             assert_eq!(username, "test");
     ///             assert_eq!(allocated_port, &None);
-    ///             assert_eq!(channel_relay_table.len(), 0);
+    ///             assert!(permissions.is_empty());
+    ///             assert!(channels.is_empty());
     ///         }
     ///         _ => panic!("Expected authenticated session"),
     ///     }
@@ -537,24 +538,27 @@ where
     ///     let lock = sessions.get_session(&identifier);
     ///     let session = lock.get_ref().unwrap();
     ///     match session {
-    ///         Session::Authenticated { username, allocated_port, channel_relay_table, .. } => {
+    ///         Session::Authenticated { username, allocated_port, permissions, channels, .. } => {
     ///             assert_eq!(username, "test");
     ///             assert_eq!(allocated_port, &None);
-    ///             assert_eq!(channel_relay_table.len(), 0);
+    ///             assert!(permissions.is_empty());
+    ///             assert!(channels.is_empty());
     ///         }
     ///         _ => panic!("Expected authenticated session"),
     ///     }
     /// }
     ///
-    /// let port = sessions.allocate(&identifier, None).unwrap();
+    /// let runtime = tokio::runtime::Runtime::new().unwrap();
+    /// let port = runtime.block_on(async { sessions.allocate(&identifier, None).unwrap() });
     /// {
     ///     let lock = sessions.get_session(&identifier);
     ///     let session = lock.get_ref().unwrap();
     ///     match session {
-    ///         Session::Authenticated { username, allocated_port, channel_relay_table, .. } => {
+    ///         Session::Authenticated { username, allocated_port, permissions, channels, .. } => {
     ///             assert_eq!(username, "test");
     ///             assert_eq!(allocated_port, &Some(port));
-    ///             assert_eq!(channel_relay_table.len(), 0);
+    ///             assert!(permissions.is_empty());
+    ///             assert!(channels.is_empty());
     ///         }
     ///         _ => panic!("Expected authenticated session"),
     ///     }

--- a/tests/turn.rs
+++ b/tests/turn.rs
@@ -43,9 +43,7 @@ async fn run_coturn_uclient(transport: Transport, send_indication: bool) -> Resu
 
     let output = String::from_utf8(output.stdout)?;
 
-    if output.contains("ERROR")
-        || !output.contains("Total lost packets 0 (0.000000%)")
-    {
+    if output.contains("ERROR") || !output.contains("Total lost packets 0 (0.000000%)") {
         return Err(anyhow!(output));
     }
 


### PR DESCRIPTION
This branch contains the TURN runtime changes I needed to run LiveKit
compatibility tests against my experimental Rust LiveKit implementation.

It adds embeddable runtime lifecycle handling, peer authorization hooks,
arbitrary-peer UDP relay support, and ChannelData padding handling.

This is an **LLM-assisted** implementation intended to unblock OxideSFU
integration testing. I understand it may not fit the upstream project's design
or review standards, and **rejection is completely fine**.

LiveKit external conformance results:

```text
PASS TestTurnRelay/allow
PASS TestTurnRelay/not-allowed
PASS TestTurnRelay/denied-overrides-allowed
PASS TestTurnAuthFailure
```

Local direct checks also passed:

```text
cargo test --lib        # 13 passed
cargo test --test stun  # 19 passed
```